### PR TITLE
feat: home UI 구현

### DIFF
--- a/src/app/_components/home.client.tsx
+++ b/src/app/_components/home.client.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import SectionPlusIcon from "@/assets/icons/selection-plus.svg";
+import { HOME_POSTS_MOCK, type PostCategory } from "@/features/post/model/post.mock";
+import { ContentCard, ContentCardBody, ContentCardFooter, ContentCardHeader, EmptyState } from "@/shared/ui";
+import { formatRelativeTime } from "@/shared/utils/format";
+import { FooterWidget } from "@/widgets/footer/ui";
+import type { SubHeadingWidgetProps } from "@/widgets/sub-heading/ui/sub-heading.widget";
+import { SubHeadingWidget } from "@/widgets/sub-heading/ui/sub-heading.widget";
+
+type HomeCategory = Extract<NonNullable<SubHeadingWidgetProps["selectedOptions"]>[number], PostCategory>;
+type HomeSortValue = NonNullable<SubHeadingWidgetProps["sortValue"]>;
+
+export default function HomePageClient() {
+  const [selectedCategories, setSelectedCategories] = useState<HomeCategory[]>([]);
+  const [sortValue, setSortValue] = useState<HomeSortValue>("latest");
+
+  const posts = useMemo(() => {
+    const filtered =
+      selectedCategories.length > 0
+        ? HOME_POSTS_MOCK.filter((post) => selectedCategories.includes(post.category))
+        : HOME_POSTS_MOCK;
+
+    const sorted = [...filtered];
+    sorted.sort((a, b) => {
+      if (sortValue === "views") {
+        return b.viewCount - a.viewCount;
+      }
+      if (sortValue === "comments") {
+        return b.comments - a.comments;
+      }
+      if (sortValue === "votes") {
+        return b.votes - a.votes;
+      }
+
+      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+    });
+    return sorted;
+  }, [selectedCategories, sortValue]);
+
+  const hasPosts = posts.length > 0;
+
+  return (
+    <div className="flex min-h-full flex-col bg-bg-01">
+      <main className="flex flex-1 flex-col gap-6 px-common-padding py-6">
+        <section className="space-y-5" aria-labelledby="home-judgment-heading">
+          <div className="space-y-2">
+            <h1 id="home-judgment-heading" className="text-heading-b text-text-04">
+              오늘의 <span className="text-secondary-strong">호구</span> 판결
+            </h1>
+            <p className="text-caption-m text-text-03">익명의 집단지성으로 당신의 선택을 검증하세요.</p>
+          </div>
+          <SubHeadingWidget
+            selectedOptions={selectedCategories}
+            sortValue={sortValue}
+            totalCount={posts.length}
+            onSelectedOptionsChange={setSelectedCategories}
+            onSortValueChange={setSortValue}
+          />
+        </section>
+
+        {hasPosts ? (
+          <section className="space-y-3" aria-labelledby="home-posts-heading">
+            <h2 id="home-posts-heading" className="sr-only">
+              게시글 목록
+            </h2>
+            <ul className="space-y-9">
+              {posts.map((post) => (
+                <li key={post.id}>
+                  <Link href={`/post/${post.id}`} className="block">
+                    <ContentCard>
+                      <ContentCardHeader
+                        authorName={post.author}
+                        category={post.category}
+                        meta={formatRelativeTime(post.createdAt)}
+                        viewCount={post.viewCount}
+                        isBookmarked={post.isBookmarked}
+                      />
+                      <ContentCardBody
+                        title={post.title}
+                        description={post.description}
+                        image={
+                          <div className={`aspect-[5/3] w-full rounded-[8px] bg-gradient-to-br ${post.images[0]}`} />
+                        }
+                        imageContainerClassName="rounded-[8px] bg-bg-02"
+                      />
+                      <ContentCardFooter votes={post.votes} comments={post.comments} />
+                    </ContentCard>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ) : (
+          <section className="flex flex-1 items-center justify-center" aria-label="게시글 없음">
+            <EmptyState
+              layout="inline"
+              contentClassName="max-w-[335px]"
+              icon={<SectionPlusIcon aria-hidden className="size-20 text-text-03" strokeWidth={8} />}
+              title={"작성된 게시글이 없습니다.\n게시글을 추가하여 판결을 받아보세요!"}
+            />
+          </section>
+        )}
+      </main>
+      <footer className="sticky bottom-0 z-20 px-common-padding">
+        <FooterWidget activeTab="home" />
+      </footer>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,5 @@
-export default function Home() {
-  return (
-    <main className="flex min-h-screen items-center justify-center bg-bg-02 px-common-padding text-center">
-      <p className="w-full max-w-common-width text-body-r text-text-03">홈 구성 중</p>
-    </main>
-  );
+import HomePageClient from "./_components/home.client";
+
+export default function HomePage() {
+  return <HomePageClient />;
 }

--- a/src/features/post/model/post.mock.ts
+++ b/src/features/post/model/post.mock.ts
@@ -1,0 +1,61 @@
+export const POST_CATEGORIES = ["중고거래", "직장", "소비", "연애", "계약", "기타"] as const;
+export type PostCategory = (typeof POST_CATEGORIES)[number];
+
+export type MockPost = {
+  id: number;
+  category: PostCategory;
+  createdAt: string;
+  title: string;
+  description: string;
+  author: string;
+  comments: number;
+  votes: number;
+  isBookmarked: boolean;
+  images: string[];
+  viewCount: number;
+};
+
+export const HOME_POSTS_MOCK: MockPost[] = [
+  {
+    id: 1,
+    category: "중고거래",
+    createdAt: "2026-05-03T10:00:00.000Z",
+    title: "아이폰 17 프로 중고로 120만원에 샀는데... 이거 호구인가요?",
+    description:
+      "이번에 아이폰 17 pro 512GB 모델을 중고거래로 120만원에 구입했습니다. 상태는 거의 새거 라고 하긴 하는데, 사고 나니까 주변에서 너무 비싸게 샀다고 난리네요.",
+    author: "김호구",
+    comments: 14,
+    votes: 911111,
+    isBookmarked: true,
+    images: ["from-indigo-50 via-emerald-50 to-sky-100", "from-amber-50 via-rose-50 to-orange-100"],
+    viewCount: 121113,
+  },
+  {
+    id: 2,
+    category: "중고거래",
+    createdAt: "2026-05-02T12:00:00.000Z",
+    title: "우녹스 노랭이 20만원 어떤가요?",
+    description:
+      "회사 주변 카페가 폐업하는데, 구형이지만 집에 오븐이 필요했던지라 냅다 예약부터 하고왔는데 괜찮을까요? 10여년전 모델이라 걱정이네요...",
+    author: "감간판",
+    comments: 21,
+    votes: 17,
+    isBookmarked: false,
+    images: ["from-cyan-50 via-blue-50 to-indigo-100", "from-emerald-50 via-lime-50 to-green-100"],
+    viewCount: 123,
+  },
+  {
+    id: 3,
+    category: "중고거래",
+    createdAt: "2026-05-01T12:00:00.000Z",
+    title: "ek43 130 어떤가요?",
+    description:
+      "안녕하세요, 요새 커피에 미쳐사는 직장인1 인사올려봅니다!\n\n 원래 커피는 그냥 카페인 수혈용이었는데 일하다 보니 커피가 거의 생명수 수준이 되어버려서… 어느 순간 브루잉 장비 하나둘 사다 보니까 집에 홈카페가 차려졌네요;;\n\n드리퍼, 서버, 필터 이런 건 얼추 맞췄는데  뭔가 계속 맛이 애매하게 부족한 느낌이 있어서  결국 그라인더까지 눈이 가는 상황입니다…\n\n 최근 출시된 옴니아(?) 영향인지 매물이 꽤 많이 올라오던데 집 주변 당X에 올라온게 130 정도거든요. 이 가격이면 괜찮은 편인가요?\n 상태는 사진상으로는 나쁘지 않아 보이긴 하는데  중고 특성상 내부 상태나 칼날 마모 이런 건 감이 안 오기도 하고... 생각보다 작은게 아니라서 소음 관련해서도 고민이네요.\n\n 좀 조언 부탁드립니다!",
+    author: "김코히",
+    comments: 8,
+    votes: 5,
+    isBookmarked: true,
+    images: ["from-violet-50 via-fuchsia-50 to-pink-100", "from-slate-100 via-zinc-100 to-neutral-200"],
+    viewCount: 123,
+  },
+];


### PR DESCRIPTION
## 📋 변경 사항

- 홈 라우트 → 클라이언트 엔트리 렌더링 구조 적용
- 홈 화면 UI 구성
- 게시글 목록/빈 상태 분기 처리 (`EmptyState` 활용)
- 카테고리 필터 및 정렬 상태(최신/조회/댓글/투표) 연동
- 게시글 카드 클릭 → `/post/[postId]` 이동 연결 (연결만 해놓고, 추후 POST에서 더 다룰 예정)

## 🏷️ PR 유형

- [x] 🚀 feat: 새로운 기능 추가
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 📝 docs: 문서 수정
- [ ] ✅ test: 테스트 코드 추가/수정
- [ ] 🔧 chore: 빌드/패키지 매니저 수정

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션 준수
- [ ] 로컬 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📸 테스트 결과

- 필터 선택/해제 시 목록 반영 확인
- 정렬 변경 시 목록 순서 반영 확인
- 데이터 없음 조건에서 빈 상태 UI(`EmptyState`) 확인
- 카드 클릭 시 `/post/[postId]` 라우팅 확인
- 하단 탭 `home` 활성 상태 확인

## 🔗 관련 이슈

- Closes #13 