### PR TITLE
feat: Search UI 구현

### DIFF
--- a/src/app/search/_components/search-page.client.tsx
+++ b/src/app/search/_components/search-page.client.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+import {
+  CATEGORY_TO_PARAM,
+  mockSearchPosts,
+  PARAM_TO_CATEGORY,
+  parseCategoryParams,
+  parseCursor,
+  parsePageSize,
+  parseSortValue,
+} from "@/features/search/model/search.mock";
+import type { CategoryLabel, SortValue } from "@/features/search/model/search.types";
+import { RecentSearchSection } from "@/features/search/ui/recent-search-section";
+import { SearchHeader } from "@/features/search/ui/search-header";
+import { SearchResultSection } from "@/features/search/ui/search-result-section";
+import { FooterWidget } from "@/widgets/footer/ui";
+
+const MAX_RECENT_SEARCHES = 10;
+const DEFAULT_CURSOR = "0";
+
+function upsertRecentSearches(previous: string[], keyword: string) {
+  const trimmed = keyword.trim();
+  if (!trimmed) {
+    return previous;
+  }
+
+  const deduplicated = previous.filter((item) => item !== trimmed);
+  return [trimmed, ...deduplicated].slice(0, MAX_RECENT_SEARCHES);
+}
+
+export default function SearchPageClient() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const keyword = searchParams.get("keyword") ?? "";
+  const selectedCategoryParams = parseCategoryParams(searchParams.get("categories"));
+  const selectedCategories = selectedCategoryParams.map((category) => PARAM_TO_CATEGORY[category]);
+  const sortValue = parseSortValue(searchParams.get("sortBy"));
+  const pageSize = parsePageSize(searchParams.get("pageSize"));
+  const cursor = parseCursor(searchParams.get("cursor"));
+  const [keywordDraft, setKeywordDraft] = useState(keyword);
+  const [recentSearches, setRecentSearches] = useState<string[]>([]);
+  const hasSearchCondition = keyword.trim().length > 0 || selectedCategories.length > 0;
+
+  useEffect(() => {
+    setKeywordDraft(keyword);
+  }, [keyword]);
+
+  const response = useMemo(
+    () =>
+      mockSearchPosts({
+        keyword,
+        categories: selectedCategoryParams,
+        sortBy: sortValue,
+        pageSize,
+        cursor,
+      }),
+    [keyword, selectedCategoryParams, sortValue, pageSize, cursor],
+  );
+
+  const pushQuery = (next: {
+    keyword?: string;
+    categories?: CategoryLabel[];
+    sortBy?: SortValue;
+    pageSize?: number;
+    cursor?: string;
+  }) => {
+    const query = new URLSearchParams(searchParams.toString());
+    const nextKeyword = next.keyword ?? keyword;
+    const nextCategories = next.categories ?? selectedCategories;
+    const nextSortBy = next.sortBy ?? sortValue;
+    const nextPageSize = String(next.pageSize ?? pageSize);
+    const nextCursor = next.cursor ?? DEFAULT_CURSOR;
+
+    if (nextKeyword) {
+      query.set("keyword", nextKeyword);
+    } else {
+      query.delete("keyword");
+    }
+
+    if (nextCategories.length > 0) {
+      query.set("categories", nextCategories.map((label) => CATEGORY_TO_PARAM[label]).join(","));
+    } else {
+      query.delete("categories");
+    }
+
+    query.set("sortBy", nextSortBy);
+    query.set("pageSize", nextPageSize);
+    query.set("cursor", nextCursor);
+
+    router.push(`${pathname}?${query.toString()}`);
+  };
+
+  const runSearch = (nextKeyword: string) => {
+    const trimmed = nextKeyword.trim();
+    setKeywordDraft(trimmed);
+    setRecentSearches((previous) => upsertRecentSearches(previous, trimmed));
+    pushQuery({ keyword: trimmed, cursor: DEFAULT_CURSOR });
+  };
+
+  return (
+    <div className="flex min-h-full flex-col bg-bg-01">
+      <main className="flex flex-1 flex-col">
+        <SearchHeader
+          keywordDraft={keywordDraft}
+          onKeywordDraftChange={setKeywordDraft}
+          onSearchSubmit={() => runSearch(keywordDraft)}
+          onBack={() => router.back()}
+        />
+
+        {hasSearchCondition ? (
+          <SearchResultSection
+            selectedCategories={selectedCategories}
+            sortValue={sortValue}
+            response={response}
+            onCategoryChange={(nextCategories) =>
+              pushQuery({
+                categories: nextCategories,
+                cursor: DEFAULT_CURSOR,
+              })
+            }
+            onSortChange={(nextSort) =>
+              pushQuery({
+                sortBy: nextSort,
+                cursor: DEFAULT_CURSOR,
+              })
+            }
+            onLoadMore={() => pushQuery({ cursor: response.nextCursor ?? undefined })}
+          />
+        ) : (
+          <RecentSearchSection
+            recentSearches={recentSearches}
+            onClearAll={() => setRecentSearches([])}
+            onSelectTerm={runSearch}
+            onRemoveTerm={(term) => setRecentSearches((prev) => prev.filter((item) => item !== term))}
+          />
+        )}
+      </main>
+
+      <footer className="sticky bottom-0 z-20 px-common-padding">
+        <FooterWidget activeTab="search" />
+      </footer>
+    </div>
+  );
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from "react";
+import SearchPageClient from "./_components/search-page.client";
+
+export default function SearchPage() {
+  return (
+    <Suspense fallback={null}>
+      <SearchPageClient />
+    </Suspense>
+  );
+}

--- a/src/features/mypage/constants/index.ts
+++ b/src/features/mypage/constants/index.ts
@@ -1,0 +1,1 @@
+export * from "./user-delete-modal.constants";

--- a/src/features/search/model/index.ts
+++ b/src/features/search/model/index.ts
@@ -1,0 +1,2 @@
+export * from "./search.mock";
+export * from "./search.types";

--- a/src/features/search/model/search.mock.ts
+++ b/src/features/search/model/search.mock.ts
@@ -1,0 +1,109 @@
+import { HOME_POSTS_MOCK } from "@/features/post/model/post.mock";
+import type { CategoryLabel, CategoryParam, SearchPostItem, SearchPostsResponse, SortValue } from "./search.types";
+
+export const CATEGORY_TO_PARAM: Record<CategoryLabel, CategoryParam> = {
+  중고거래: "TRADE",
+  직장: "WORK",
+  소비: "SPEND",
+  연애: "RELATIONSHIP",
+  계약: "CONTRACT",
+  기타: "ETC",
+};
+
+export const PARAM_TO_CATEGORY: Record<CategoryParam, CategoryLabel> = {
+  TRADE: "중고거래",
+  WORK: "직장",
+  SPEND: "소비",
+  RELATIONSHIP: "연애",
+  CONTRACT: "계약",
+  ETC: "기타",
+};
+
+export const SEARCH_POSTS_MOCK: SearchPostItem[] = HOME_POSTS_MOCK.map((post) => ({
+  postId: post.id,
+  isBookmarked: post.isBookmarked,
+  categories: CATEGORY_TO_PARAM[post.category as CategoryLabel] ?? "TRADE",
+  title: post.title,
+  createdAt: post.createdAt,
+  viewCount: post.viewCount,
+  contentPreview: post.description,
+  thumbnailUrl: post.images[0] ?? "from-slate-100 via-zinc-100 to-neutral-200",
+  totalVoteCount: post.votes,
+  commentCount: post.comments,
+  writer: {
+    nickname: post.author,
+    profileImageUrl: "",
+  },
+}));
+
+export function parseSortValue(value: string | null): SortValue {
+  if (value === "views" || value === "comments" || value === "votes") {
+    return value;
+  }
+  return "latest";
+}
+
+export function parsePageSize(value: string | null) {
+  const pageSize = Number(value);
+  if (!Number.isFinite(pageSize) || pageSize <= 0) {
+    return 10;
+  }
+  return Math.min(pageSize, 30);
+}
+
+export function parseCursor(value: string | null) {
+  const cursor = Number(value);
+  if (!Number.isFinite(cursor) || cursor < 0) {
+    return 0;
+  }
+  return cursor;
+}
+
+export function parseCategoryParams(value: string | null): CategoryParam[] {
+  if (!value) {
+    return [];
+  }
+  const raw = value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  return raw.filter((item): item is CategoryParam => item in PARAM_TO_CATEGORY);
+}
+
+export function mockSearchPosts(params: {
+  keyword: string;
+  categories: CategoryParam[];
+  sortBy: SortValue;
+  pageSize: number;
+  cursor: number;
+}): SearchPostsResponse {
+  const { keyword, categories, sortBy, pageSize, cursor } = params;
+  const normalizedKeyword = keyword.trim().toLowerCase();
+
+  const filtered = SEARCH_POSTS_MOCK.filter((post) => {
+    const matchesKeyword =
+      normalizedKeyword.length === 0 ||
+      post.title.toLowerCase().includes(normalizedKeyword) ||
+      post.contentPreview.toLowerCase().includes(normalizedKeyword) ||
+      post.writer.nickname.toLowerCase().includes(normalizedKeyword);
+    const matchesCategory = categories.length === 0 || categories.includes(post.categories);
+    return matchesKeyword && matchesCategory;
+  });
+
+  const sorted = [...filtered].sort((a, b) => {
+    if (sortBy === "views") return b.viewCount - a.viewCount;
+    if (sortBy === "comments") return b.commentCount - a.commentCount;
+    if (sortBy === "votes") return b.totalVoteCount - a.totalVoteCount;
+    return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+  });
+
+  const pagePosts = sorted.slice(cursor, cursor + pageSize);
+  const nextCursorValue = cursor + pagePosts.length;
+
+  return {
+    totalPostCount: sorted.length,
+    posts: pagePosts,
+    hasNext: nextCursorValue < sorted.length,
+    nextCursor: nextCursorValue < sorted.length ? String(nextCursorValue) : null,
+  };
+}

--- a/src/features/search/model/search.types.ts
+++ b/src/features/search/model/search.types.ts
@@ -1,0 +1,30 @@
+import type { POST_FILTER_OPTIONS } from "@/features/post/constants/post-filter.constants";
+import type { SubHeadingWidgetProps } from "@/widgets/sub-heading/ui/sub-heading.widget";
+
+export type SortValue = NonNullable<SubHeadingWidgetProps["sortValue"]>;
+export type CategoryLabel = (typeof POST_FILTER_OPTIONS)[number];
+export type CategoryParam = "TRADE" | "WORK" | "SPEND" | "RELATIONSHIP" | "CONTRACT" | "ETC";
+
+export type SearchPostItem = {
+  postId: number;
+  isBookmarked: boolean;
+  categories: CategoryParam;
+  title: string;
+  createdAt: string;
+  viewCount: number;
+  contentPreview: string;
+  thumbnailUrl: string;
+  totalVoteCount: number;
+  commentCount: number;
+  writer: {
+    nickname: string;
+    profileImageUrl: string;
+  };
+};
+
+export type SearchPostsResponse = {
+  totalPostCount: number;
+  posts: SearchPostItem[];
+  hasNext: boolean;
+  nextCursor: string | null;
+};

--- a/src/features/search/ui/index.ts
+++ b/src/features/search/ui/index.ts
@@ -1,0 +1,3 @@
+export * from "./recent-search-section";
+export * from "./search-header";
+export * from "./search-result-section";

--- a/src/features/search/ui/recent-search-section.tsx
+++ b/src/features/search/ui/recent-search-section.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import XIcon from "@/assets/icons/x.svg";
+
+type RecentSearchSectionProps = {
+  recentSearches: string[];
+  onClearAll: () => void;
+  onSelectTerm: (term: string) => void;
+  onRemoveTerm: (term: string) => void;
+};
+
+export function RecentSearchSection(props: RecentSearchSectionProps) {
+  const { recentSearches, onClearAll, onSelectTerm, onRemoveTerm } = props;
+
+  return (
+    <section aria-label="최근 검색어" className="flex-1">
+      <div className="flex items-center justify-between border-b border-line-02 px-common-padding py-4">
+        <h2 className="text-body-m text-text-04">최근 검색어</h2>
+        <button type="button" className="text-caption-m text-text-03" onClick={onClearAll}>
+          전체 삭제
+        </button>
+      </div>
+
+      {recentSearches.length > 0 ? (
+        <ul>
+          {recentSearches.map((term) => (
+            <li key={term} className="flex items-center justify-between px-common-padding py-4">
+              <button type="button" className="text-body-m text-text-03" onClick={() => onSelectTerm(term)}>
+                {term}
+              </button>
+              <button type="button" aria-label={`${term} 검색어 삭제`} onClick={() => onRemoveTerm(term)}>
+                <XIcon aria-hidden className="size-4 text-text-03" strokeWidth={20} />
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="px-common-padding py-4 text-body-m text-text-03">최근 검색된 검색어가 없습니다.</p>
+      )}
+    </section>
+  );
+}

--- a/src/features/search/ui/search-header.tsx
+++ b/src/features/search/ui/search-header.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import ArrowLeftIcon from "@/assets/icons/arrow-left.svg";
+import { SearchTextfield } from "@/shared/ui";
+
+type SearchHeaderProps = {
+  keywordDraft: string;
+  onKeywordDraftChange: (value: string) => void;
+  onSearchSubmit: () => void;
+  onBack: () => void;
+};
+
+export function SearchHeader(props: SearchHeaderProps) {
+  const { keywordDraft, onKeywordDraftChange, onSearchSubmit, onBack } = props;
+
+  return (
+    <section className="bg-bg-02 px-common-padding pb-4 pt-4" aria-label="검색 헤더">
+      <div className="flex items-center gap-2">
+        <button type="button" aria-label="뒤로가기" onClick={onBack}>
+          <ArrowLeftIcon aria-hidden className="size-5 text-text-03" strokeWidth={20} />
+        </button>
+        <div className="flex-1">
+          <SearchTextfield
+            className="bg-bg-01"
+            value={keywordDraft}
+            onChange={(event) => {
+              // TODO: 타이핑 시 연관 검색어(suggestion) API 연동 및 드롭다운 UI 노출 처리
+              onKeywordDraftChange(event.target.value);
+            }}
+            placeholder="검색어를 입력해주세요."
+            showClearButton
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                onSearchSubmit();
+              }
+            }}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/search/ui/search-result-section.tsx
+++ b/src/features/search/ui/search-result-section.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import Link from "next/link";
+import { PARAM_TO_CATEGORY } from "@/features/search/model/search.mock";
+import type { CategoryLabel, SearchPostsResponse, SortValue } from "@/features/search/model/search.types";
+import { ContentCard, ContentCardBody, ContentCardFooter, ContentCardHeader } from "@/shared/ui";
+import { formatRelativeTime } from "@/shared/utils/format";
+import { SubHeadingWidget } from "@/widgets/sub-heading/ui/sub-heading.widget";
+
+type SearchResultSectionProps = {
+  selectedCategories: CategoryLabel[];
+  sortValue: SortValue;
+  response: SearchPostsResponse;
+  onCategoryChange: (nextCategories: CategoryLabel[]) => void;
+  onSortChange: (nextSort: SortValue) => void;
+  onLoadMore: () => void;
+};
+
+export function SearchResultSection(props: SearchResultSectionProps) {
+  const { selectedCategories, sortValue, response, onCategoryChange, onSortChange, onLoadMore } = props;
+
+  return (
+    <div className="flex flex-1 flex-col gap-5 px-common-padding py-5">
+      <section className="flex flex-col gap-3" aria-label="탐색 필터">
+        <SubHeadingWidget
+          selectedOptions={selectedCategories}
+          sortValue={sortValue}
+          totalCount={response.totalPostCount}
+          onSelectedOptionsChange={onCategoryChange}
+          onSortValueChange={onSortChange}
+        />
+      </section>
+
+      {response.posts.length > 0 ? (
+        <section className="flex flex-col gap-3" aria-label="검색 게시글 목록">
+          <ul className="flex flex-col gap-4">
+            {response.posts.map((post) => (
+              <li key={post.postId}>
+                <Link href={`/post/${post.postId}`} className="block">
+                  <ContentCard>
+                    <ContentCardHeader
+                      authorName={post.writer.nickname}
+                      authorImage={post.writer.profileImageUrl || undefined}
+                      category={PARAM_TO_CATEGORY[post.categories]}
+                      meta={formatRelativeTime(post.createdAt)}
+                      viewCount={post.viewCount}
+                      isBookmarked={post.isBookmarked}
+                    />
+                    <ContentCardBody
+                      title={post.title}
+                      description={post.contentPreview}
+                      image={
+                        <div className={`aspect-[5/3] w-full rounded-[8px] bg-gradient-to-br ${post.thumbnailUrl}`} />
+                      }
+                    />
+                    <ContentCardFooter votes={post.totalVoteCount} comments={post.commentCount} />
+                  </ContentCard>
+                </Link>
+              </li>
+            ))}
+          </ul>
+          {response.hasNext && response.nextCursor ? (
+            <button
+              type="button"
+              onClick={onLoadMore}
+              className="w-full rounded-[12px] bg-bg-02 px-4 py-3 text-caption-sb text-text-03"
+            >
+              더 보기
+            </button>
+          ) : null}
+        </section>
+      ) : (
+        <section
+          className="flex flex-1 items-center justify-center text-caption-m text-text-03"
+          aria-label="검색 결과 없음"
+        >
+          검색 결과가 없습니다.
+        </section>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 📋 변경 사항

- 검색 페이지 라우팅 및 클라이언트 엔트리 연결
- 검색 쿼리(`keyword/categories/sortBy/pageSize/cursor`) API 명세 기준으로 반영
+) mock 기반 필터/정렬/커서 페이지네이션 구현
- 검색 UI(`header/recent/result`) 및 조건부 분기(최근 검색어/결과 목록) 구현
- 더 보기(커서 기반) 동작 및 하단 탭 `search` 활성 상태 연결
- TODO 명시: 연관 검색어 API/드롭다운 후속 연동
- `app/search/_components/search-page.client.tsx` 컴포넌트의 경우, 추후 리팩토링 필요 
(사유: 너무 김...)
- `features` 하위 누락된 index export 정리

## 🏷️ PR 유형

- [x] 🚀 feat: 새로운 기능 추가
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 📝 docs: 문서 수정
- [ ] ✅ test: 테스트 코드 추가/수정
- [ ] 🔧 chore: 빌드/패키지 매니저 수정

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션 준수
- [ ] 로컬 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📸 테스트 결과

- 주요 검색 플로우 체크 완

## 🔗 관련 이슈

- Closes #14 
