### PR TITLE
feat: API 초기 연동 구조 설정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import { GlobalFloatingControls } from "@/features/home/ui";
+import { QueryProvider } from "@/shared/providers/query-provider";
 import "./globals.css";
 
 // 폰트 설정
@@ -26,12 +27,14 @@ export default function RootLayout({
   return (
     <html lang="ko" className={`${pretendard.variable} h-full antialiased`}>
       <body className={`${pretendard.className} min-h-full flex`}>
-        <div className="flex w-full grow flex-row justify-center">
-          <div id="app-layout" className="max-w-common-width flex w-full flex-col shadow-2xl">
-            {children}
-            <GlobalFloatingControls />
+        <QueryProvider>
+          <div className="flex w-full grow flex-row justify-center">
+            <div id="app-layout" className="max-w-common-width flex w-full flex-col shadow-2xl">
+              {children}
+              <GlobalFloatingControls />
+            </div>
           </div>
-        </div>
+        </QueryProvider>
       </body>
     </html>
   );

--- a/src/features/post/api/index.ts
+++ b/src/features/post/api/index.ts
@@ -1,0 +1,4 @@
+export * from "./post.action";
+export * from "./post.keys";
+export * from "./post.query";
+export * from "./post.service";

--- a/src/features/post/api/post.action.ts
+++ b/src/features/post/api/post.action.ts
@@ -1,0 +1,26 @@
+"use server";
+
+import { type ApiResult, apiFailure, apiSuccess } from "@/shared/api";
+import {
+  type GetHomePostsParams,
+  getHomePosts,
+  getPostDetail,
+  type HomePostsResponse,
+  type PostDetailResponse,
+} from "./post.service";
+
+export async function getHomePostsAction(params: GetHomePostsParams = {}): Promise<ApiResult<HomePostsResponse>> {
+  try {
+    return apiSuccess(await getHomePosts(params));
+  } catch (error) {
+    return apiFailure(error);
+  }
+}
+
+export async function getPostDetailAction(postId: number): Promise<ApiResult<PostDetailResponse>> {
+  try {
+    return apiSuccess(await getPostDetail(postId));
+  } catch (error) {
+    return apiFailure(error);
+  }
+}

--- a/src/features/post/api/post.keys.ts
+++ b/src/features/post/api/post.keys.ts
@@ -1,0 +1,3 @@
+import { createDomainQueryKeys } from "@/shared/api";
+
+export const postQueryKeys = createDomainQueryKeys("posts");

--- a/src/features/post/api/post.query.ts
+++ b/src/features/post/api/post.query.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { unwrapApiResult } from "@/shared/api";
+import { getHomePostsAction, getPostDetailAction } from "./post.action";
+import { postQueryKeys } from "./post.keys";
+import type { GetHomePostsParams } from "./post.service";
+
+export function useHomePostsQuery(params: GetHomePostsParams = {}) {
+  return useQuery({
+    queryKey: postQueryKeys.list(params),
+    queryFn: () => getHomePostsAction(params).then(unwrapApiResult),
+  });
+}
+
+export function usePostDetailQuery(postId: number) {
+  return useQuery({
+    queryKey: postQueryKeys.detail(postId),
+    queryFn: () => getPostDetailAction(postId).then(unwrapApiResult),
+    enabled: Number.isFinite(postId),
+  });
+}

--- a/src/features/post/api/post.service.ts
+++ b/src/features/post/api/post.service.ts
@@ -1,0 +1,25 @@
+import { apiClient } from "@/shared/api";
+
+export type GetHomePostsParams = {
+  keyword?: string;
+  categories?: string;
+  sortBy?: string;
+  pageSize?: number;
+  cursor?: string;
+};
+
+export type HomePostsResponse = unknown;
+export type PostDetailResponse = unknown;
+
+export async function getHomePosts(params: GetHomePostsParams = {}) {
+  return apiClient<HomePostsResponse>("/posts", {
+    method: "GET",
+    query: params,
+  });
+}
+
+export async function getPostDetail(postId: number) {
+  return apiClient<PostDetailResponse>(`/posts/${postId}`, {
+    method: "GET",
+  });
+}

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -1,0 +1,94 @@
+import { ApiError } from "./error";
+
+const DEFAULT_API_TIMEOUT_MS = 15_000;
+
+type JsonRecord = Record<string, unknown>;
+
+export type ApiClientOptions = Omit<RequestInit, "body"> & {
+  body?: BodyInit | JsonRecord | unknown[] | null;
+  query?: Record<string, string | number | boolean | null | undefined>;
+  timeoutMs?: number;
+};
+
+function getApiBaseUrl() {
+  return process.env.API_BASE_URL ?? process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
+}
+
+function createApiUrl(path: string, query?: ApiClientOptions["query"]) {
+  const baseUrl = getApiBaseUrl();
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  const url = baseUrl ? new URL(normalizedPath, baseUrl) : new URL(normalizedPath, "http://localhost");
+
+  for (const [key, value] of Object.entries(query ?? {})) {
+    if (value !== null && value !== undefined) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+
+  return baseUrl ? url.toString() : `${url.pathname}${url.search}`;
+}
+
+function isJsonBody(body: ApiClientOptions["body"]): body is JsonRecord | unknown[] {
+  return Boolean(body) && typeof body === "object" && !(body instanceof FormData) && !(body instanceof Blob);
+}
+
+async function parseResponseBody(response: Response) {
+  if (response.status === 204) {
+    return null;
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    return response.json();
+  }
+
+  return response.text();
+}
+
+function getErrorMessage(data: unknown, fallback: string) {
+  if (data && typeof data === "object" && "message" in data && typeof data.message === "string") {
+    return data.message;
+  }
+
+  return fallback;
+}
+
+export async function apiClient<T>(path: string, options: ApiClientOptions = {}): Promise<T> {
+  const { body, headers, query, timeoutMs = DEFAULT_API_TIMEOUT_MS, ...requestInit } = options;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  const shouldJsonStringify = isJsonBody(body);
+
+  try {
+    const response = await fetch(createApiUrl(path, query), {
+      ...requestInit,
+      body: shouldJsonStringify ? JSON.stringify(body) : body,
+      headers: {
+        ...(shouldJsonStringify ? { "Content-Type": "application/json" } : {}),
+        ...headers,
+      },
+      signal: controller.signal,
+    });
+    const data = await parseResponseBody(response);
+
+    if (!response.ok) {
+      throw new ApiError({
+        status: response.status,
+        message: getErrorMessage(data, response.statusText),
+        data,
+      });
+    }
+
+    return data as T;
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw new ApiError({
+        message: `Request timed out after ${timeoutMs} ms`,
+      });
+    }
+
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/src/shared/api/error.ts
+++ b/src/shared/api/error.ts
@@ -1,0 +1,50 @@
+// API 호출 실패를 표현하는 공통 에러입니다.
+// `src/app/error.tsx`는 렌더링이 실패했을 때 보여주는 글로벌 에러 화면이고,
+// 이 파일의 `ApiError`는 400/401/404/500, timeout 같은 API 응답 실패를
+// TanStack Query나 server action에서 다루기 위한 데이터 계층 에러입니다.
+
+export type ApiErrorPayload = {
+  status?: number;
+  message: string;
+  data?: unknown;
+};
+
+export class ApiError extends Error {
+  status?: number;
+  data?: unknown;
+
+  constructor(payload: ApiErrorPayload) {
+    super(payload.message);
+    this.name = "ApiError";
+    this.status = payload.status;
+    this.data = payload.data;
+  }
+}
+
+export function isApiError(error: unknown): error is ApiError {
+  return error instanceof ApiError;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (isApiError(error)) {
+    return error.message;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+
+  return "알 수 없는 오류가 발생했습니다.";
+}
+
+export function toApiError(error: unknown): ApiError {
+  if (isApiError(error)) {
+    return error;
+  }
+
+  return new ApiError({
+    message: getErrorMessage(error),
+  });
+}

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -1,0 +1,5 @@
+export * from "./client";
+export * from "./error";
+export * from "./query-client";
+export * from "./query-key";
+export * from "./result";

--- a/src/shared/api/query-client.ts
+++ b/src/shared/api/query-client.ts
@@ -1,0 +1,13 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        refetchOnWindowFocus: false,
+        retry: false,
+        staleTime: 60 * 1000,
+      },
+    },
+  });
+}

--- a/src/shared/api/query-key.ts
+++ b/src/shared/api/query-key.ts
@@ -1,0 +1,11 @@
+type QueryKeyPart = string | number | boolean | null | undefined | Record<string, unknown>;
+
+export function createDomainQueryKeys<const TDomain extends string>(domain: TDomain) {
+  return {
+    all: [domain] as const,
+    lists: () => [domain, "list"] as const,
+    list: (...params: QueryKeyPart[]) => [domain, "list", ...params] as const,
+    details: () => [domain, "detail"] as const,
+    detail: (id: string | number) => [domain, "detail", id] as const,
+  };
+}

--- a/src/shared/api/result.ts
+++ b/src/shared/api/result.ts
@@ -1,0 +1,41 @@
+import { ApiError, type ApiErrorPayload, toApiError } from "./error";
+
+export type ApiSuccess<T> = {
+  success: true;
+  data: T;
+};
+
+export type ApiFailure = {
+  success: false;
+  error: ApiErrorPayload;
+};
+
+export type ApiResult<T> = ApiSuccess<T> | ApiFailure;
+
+export function apiSuccess<T>(data: T): ApiSuccess<T> {
+  return {
+    success: true,
+    data,
+  };
+}
+
+export function apiFailure(error: unknown): ApiFailure {
+  const apiError = toApiError(error);
+
+  return {
+    success: false,
+    error: {
+      status: apiError.status,
+      message: apiError.message,
+      data: apiError.data,
+    },
+  };
+}
+
+export function unwrapApiResult<T>(result: ApiResult<T>): T {
+  if (result.success) {
+    return result.data;
+  }
+
+  throw new ApiError(result.error);
+}

--- a/src/shared/providers/query-provider.tsx
+++ b/src/shared/providers/query-provider.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { isServer, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import type { ReactNode } from "react";
+import { makeQueryClient } from "@/shared/api";
+
+let browserQueryClient: ReturnType<typeof makeQueryClient> | undefined;
+
+function getQueryClient() {
+  if (isServer) {
+    return makeQueryClient();
+  }
+
+  browserQueryClient ??= makeQueryClient();
+  return browserQueryClient;
+}
+
+export function QueryProvider({ children }: { children: ReactNode }) {
+  const queryClient = getQueryClient();
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      {process.env.NODE_ENV === "development" ? <ReactQueryDevtools /> : null}
+    </QueryClientProvider>
+  );
+}


### PR DESCRIPTION
## 📋 변경 사항

Swagger/OpenAPI spec이 아직 제공되지 않은 상태에서
추후 OpenAPI 기반 TypeScript fetch client 자동 생성으로 전환하기 쉬운 프론트 API 연동 베이스를 설정했습니다.

이번 PR은 실제 API 연동이나 mock 데이터 제거가 아니라
팀원들이 같은 방식으로 API를 붙일 수 있도록 공통 구조를 먼저 마련하는 작업입니다.

### 1. 공통 API 인프라 추가

`src/shared/api`에 API 호출 공통 유틸을 추가했습니다.

```txt
src/shared/api/
  client.ts        // 공통 fetch wrapper
  error.ts         // API 에러 표준화
  result.ts        // server action 결과 포맷
  query-client.ts  // TanStack Query 기본 설정
  query-key.ts     // query key 생성 helper
  index.ts
```

주요 기준은 다음과 같습니다.

- API 요청은 `apiClient`를 통해 수행합니다.
- HTTP 실패 응답은 `ApiError`로 표준화합니다.
- server action은 `{ success: true, data } | { success: false, error }` 형태의 `ApiResult`를 반환합니다.
- query hook에서는 `unwrapApiResult`를 사용해 TanStack Query의 `error`, `isError` 흐름으로 연결합니다.

### 2. TanStack Query Provider 연결

`src/shared/providers/query-provider.tsx`를 추가하고, `src/app/layout.tsx`에서 루트 앱을 감싸도록 연결했습니다.

기본 query 옵션은 공통 client에서 관리합니다.

- `retry: false`
- `refetchOnWindowFocus: false`
- `staleTime: 60초`
- 개발 환경에서만 React Query Devtools 표시

### 3. 게시글 API 스캐폴드 추가

도메인 API 구조 예시로 `src/features/post/api`를 추가했습니다.

```txt
src/features/post/api/
  post.keys.ts
  post.service.ts
  post.action.ts
  post.query.ts
  index.ts
```

각 파일의 역할은 다음과 같습니다.

- `post.keys.ts`: 게시글 query key 관리
- `post.service.ts`: 실제 API 호출 함수 정의
- `post.action.ts`: server action 경계 및 `ApiResult` 반환
- `post.query.ts`: TanStack Query hook 정의
- `index.ts`: 외부 export 정리

현재는 Swagger/OpenAPI spec과 최종 DTO가 준비되기 전이므로, 실제 화면에는 연결하지 않고 구조 예시만 추가했습니다.

## 협업 가이드

### Swagger 제공 전

백엔드 Swagger/OpenAPI spec이 준비되기 전까지는 아래 기준으로 작업합니다.

1. mock 데이터는 당장 제거하지 않습니다.
2. 서버 계약이 안정된 endpoint만 수동으로 `service/action/query`에 추가합니다.
3. API 호출은 `src/shared/api/client.ts`의 `apiClient`를 사용합니다.
4. API 실패는 `ApiError` / `ApiResult` 흐름으로 처리합니다.
5. 화면 연결은 loading/error UI까지 준비된 경우에만 진행합니다.

### Swagger 제공 후

백엔드에서 raw OpenAPI JSON/YAML spec이 제공되면 아래 방향으로 전환합니다.

```txt
OpenAPI JSON/YAML
-> openapi-generator typescript-fetch client 생성
-> service 내부 구현을 생성 client 기반으로 교체
-> 필요하면 domain api scaffold generator 추가
```

즉, 현재 구조는 Swagger 도입 전 임시 구조이면서도, 추후 자동 생성 client로 전환하기 위한 브릿지 구조입니다.

### 에러 처리 기준

`src/app/error.tsx`는 렌더링 실패나 예상하지 못한 예외를 처리하는 글로벌 에러 화면입니다.

`src/shared/api/error.ts`의 `ApiError`는 API 응답 실패를 처리하기 위한 데이터 계층 에러입니다.

API 400/401/404/500 같은 실패를 전부 글로벌 에러 화면으로 보내지 않고, 화면별로 toast / inline error / retry UI / form error 등으로 처리할 수 있도록 분리했습니다.

## 🏷️ PR 유형

- [x] 🚀 feat: 새로운 기능 추가
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 📝 docs: 문서 수정
- [ ] ✅ test: 테스트 코드 추가/수정
- [ ] 🔧 chore: 빌드/패키지 매니저 수정

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션 준수
- [x] 로컬 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📸 테스트 결과
```bash
pnpm check 완료
```

## 🔗 관련 이슈

- Closes #29