### PR TITLE
feat: 온보딩 회원 생성 및 닉네임 검증 연동

### DIFF
--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,0 +1,40 @@
+import type { NextRequest } from "next/server";
+
+function getApiBaseUrl() {
+  return process.env.API_BASE_URL ?? process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
+}
+
+function createApiUrl(path: string) {
+  const baseUrl = getApiBaseUrl();
+
+  if (!baseUrl) {
+    throw new Error("API_BASE_URL이 설정되지 않았습니다.");
+  }
+
+  return new URL(path, baseUrl);
+}
+
+function createForwardHeaders(request: NextRequest) {
+  const headers = new Headers();
+  const contentType = request.headers.get("content-type");
+  const cookie = request.headers.get("cookie");
+
+  if (contentType) {
+    headers.set("Content-Type", contentType);
+  }
+
+  if (cookie) {
+    headers.set("Cookie", cookie);
+  }
+
+  return headers;
+}
+
+export async function POST(request: NextRequest) {
+  return fetch(createApiUrl("/api/users"), {
+    method: "POST",
+    headers: createForwardHeaders(request),
+    body: await request.text(),
+    cache: "no-store",
+  });
+}

--- a/src/app/onboarding/_components/onboarding-page.client.tsx
+++ b/src/app/onboarding/_components/onboarding-page.client.tsx
@@ -1,16 +1,41 @@
 "use client";
 
+import { useRouter } from "next/navigation";
+import { useState } from "react";
 import { Controller } from "react-hook-form";
+import { createOnboardingUser } from "@/features/onboarding/api";
 import { useOnboardingForm } from "@/features/onboarding/hooks";
 import type { OnboardingFormData } from "@/features/onboarding/models";
+import { getOnboardingNicknameErrorMessage, getOnboardingSubmitErrorMessage } from "@/features/onboarding/utils";
+import { toApiError } from "@/shared/api";
 import { Button, Textfield } from "@/shared/ui";
 
 export default function OnboardingPageClient() {
-  const { control, handleSubmit, helperText, tone, isValid } = useOnboardingForm();
+  const router = useRouter();
+  const [submitErrorMessage, setSubmitErrorMessage] = useState<string | null>(null);
+  const { control, handleSubmit, helperText, tone, isCheckingNickname, isValid, setError } = useOnboardingForm();
 
-  const handleOnboardingSubmit = (data: OnboardingFormData) => {
-    // TODO: 온보딩 완료 API 연동 후 홈 또는 이전 페이지로 이동
-    console.log("제출된 데이터:", data);
+  const handleOnboardingSubmit = async (data: OnboardingFormData) => {
+    setSubmitErrorMessage(null);
+
+    try {
+      await createOnboardingUser(data);
+      router.replace("/");
+      return;
+    } catch (error) {
+      const apiError = toApiError(error);
+      const nicknameErrorMessage = getOnboardingNicknameErrorMessage(apiError.data);
+
+      if (nicknameErrorMessage) {
+        setError("nickname", {
+          type: "server",
+          message: nicknameErrorMessage,
+        });
+        return;
+      }
+
+      setSubmitErrorMessage(getOnboardingSubmitErrorMessage(apiError.data));
+    }
   };
 
   return (
@@ -44,9 +69,21 @@ export default function OnboardingPageClient() {
         </div>
       </section>
 
-      <Button type="submit" disabled={!isValid} variant={isValid ? "primary" : "disabled"} fullWidth>
-        완료하기
-      </Button>
+      <div className="flex flex-col gap-3">
+        {submitErrorMessage ? (
+          <p className="text-center text-small-m text-danger" role="alert">
+            {submitErrorMessage}
+          </p>
+        ) : null}
+        <Button
+          type="submit"
+          disabled={!isValid || isCheckingNickname}
+          variant={isValid && !isCheckingNickname ? "primary" : "disabled"}
+          fullWidth
+        >
+          완료하기
+        </Button>
+      </div>
     </form>
   );
 }

--- a/src/app/onboarding/_components/onboarding-page.client.tsx
+++ b/src/app/onboarding/_components/onboarding-page.client.tsx
@@ -13,9 +13,9 @@ import { Button, Textfield } from "@/shared/ui";
 export default function OnboardingPageClient() {
   const router = useRouter();
   const [submitErrorMessage, setSubmitErrorMessage] = useState<string | null>(null);
-  const { control, handleSubmit, helperText, tone, isCheckingNickname, isSubmitting, isValid, setError } =
+  const { control, handleSubmit, helperText, tone, isNicknameCheckPending, isSubmitting, isValid, setError } =
     useOnboardingForm();
-  const isSubmitDisabled = !isValid || isCheckingNickname || isSubmitting;
+  const isSubmitDisabled = !isValid || isNicknameCheckPending || isSubmitting;
 
   const handleOnboardingSubmit = async (data: OnboardingFormData) => {
     setSubmitErrorMessage(null);

--- a/src/app/onboarding/_components/onboarding-page.client.tsx
+++ b/src/app/onboarding/_components/onboarding-page.client.tsx
@@ -13,7 +13,9 @@ import { Button, Textfield } from "@/shared/ui";
 export default function OnboardingPageClient() {
   const router = useRouter();
   const [submitErrorMessage, setSubmitErrorMessage] = useState<string | null>(null);
-  const { control, handleSubmit, helperText, tone, isCheckingNickname, isValid, setError } = useOnboardingForm();
+  const { control, handleSubmit, helperText, tone, isCheckingNickname, isSubmitting, isValid, setError } =
+    useOnboardingForm();
+  const isSubmitDisabled = !isValid || isCheckingNickname || isSubmitting;
 
   const handleOnboardingSubmit = async (data: OnboardingFormData) => {
     setSubmitErrorMessage(null);
@@ -75,12 +77,7 @@ export default function OnboardingPageClient() {
             {submitErrorMessage}
           </p>
         ) : null}
-        <Button
-          type="submit"
-          disabled={!isValid || isCheckingNickname}
-          variant={isValid && !isCheckingNickname ? "primary" : "disabled"}
-          fullWidth
-        >
+        <Button type="submit" disabled={isSubmitDisabled} variant={isSubmitDisabled ? "disabled" : "primary"} fullWidth>
           완료하기
         </Button>
       </div>

--- a/src/features/onboarding/api/index.ts
+++ b/src/features/onboarding/api/index.ts
@@ -1,0 +1,1 @@
+export * from "./onboarding.service";

--- a/src/features/onboarding/api/onboarding.action.ts
+++ b/src/features/onboarding/api/onboarding.action.ts
@@ -1,0 +1,13 @@
+"use server";
+
+import { type ApiResult, apiFailure, apiSuccess } from "@/shared/api";
+import type { CheckNicknameResponse } from "@/shared/api/generated";
+import { checkNickname } from "./onboarding.service";
+
+export async function checkNicknameAction(nickname: string): Promise<ApiResult<CheckNicknameResponse>> {
+  try {
+    return apiSuccess(await checkNickname(nickname));
+  } catch (error) {
+    return apiFailure(error);
+  }
+}

--- a/src/features/onboarding/api/onboarding.service.ts
+++ b/src/features/onboarding/api/onboarding.service.ts
@@ -1,0 +1,18 @@
+import { apiClient } from "@/shared/api";
+import type { CheckNicknameResponse, OnboardingRequest, OnboardingResponse } from "@/shared/api/generated";
+
+export async function checkNickname(nickname: string) {
+  return apiClient<CheckNicknameResponse>("/api/users/check-nickname", {
+    method: "GET",
+    query: {
+      nickname,
+    },
+  });
+}
+
+export async function createOnboardingUser(request: OnboardingRequest) {
+  return apiClient<OnboardingResponse>("/api/users", {
+    method: "POST",
+    body: request,
+  });
+}

--- a/src/features/onboarding/hooks/use-onboarding-form.hook.ts
+++ b/src/features/onboarding/hooks/use-onboarding-form.hook.ts
@@ -8,7 +8,7 @@ import { getNicknameCheckErrorMessage } from "@/features/onboarding/utils";
 const NICKNAME_CHECK_DELAY_MS = 500;
 
 export function useOnboardingForm() {
-  const [isCheckingNickname, setIsCheckingNickname] = useState(false);
+  const [isNicknameCheckPending, setIsNicknameCheckPending] = useState(false);
   const latestCheckIdRef = useRef(0);
   const {
     clearErrors,
@@ -33,17 +33,16 @@ export function useOnboardingForm() {
   useEffect(() => {
     if (!nicknameValue || hasNicknameFormatError) {
       latestCheckIdRef.current += 1;
-      setIsCheckingNickname(false);
+      setIsNicknameCheckPending(false);
       return;
     }
 
     const checkId = latestCheckIdRef.current + 1;
     latestCheckIdRef.current = checkId;
+    setIsNicknameCheckPending(true);
 
     // Debouncing을 위한 timer
     const timeoutId = window.setTimeout(async () => {
-      setIsCheckingNickname(true);
-
       const result = await checkNicknameAction(nicknameValue);
 
       // 마지막 요청이 아닐 경우 중지한다.
@@ -51,7 +50,7 @@ export function useOnboardingForm() {
         return;
       }
 
-      setIsCheckingNickname(false);
+      setIsNicknameCheckPending(false);
 
       // type: "server"는 실제 API 요청 후, 서버에서 받은 에러를 나타낸다.
       if (!result.success) {
@@ -86,7 +85,7 @@ export function useOnboardingForm() {
       };
     }
 
-    if (isCheckingNickname) {
+    if (isNicknameCheckPending) {
       return {
         helperText: "닉네임 중복 확인 중입니다.",
         tone: "default" as const,
@@ -115,7 +114,7 @@ export function useOnboardingForm() {
   return {
     control,
     handleSubmit,
-    isCheckingNickname,
+    isNicknameCheckPending,
     isSubmitting,
     isValid,
     setError,

--- a/src/features/onboarding/hooks/use-onboarding-form.hook.ts
+++ b/src/features/onboarding/hooks/use-onboarding-form.hook.ts
@@ -1,11 +1,20 @@
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
+import { checkNicknameAction } from "@/features/onboarding/api/onboarding.action";
 import { type OnboardingFormData, onboardingSchema } from "@/features/onboarding/models";
+import { getNicknameCheckErrorMessage } from "@/features/onboarding/utils";
+
+const NICKNAME_CHECK_DELAY_MS = 500;
 
 export function useOnboardingForm() {
+  const [isCheckingNickname, setIsCheckingNickname] = useState(false);
+  const latestCheckIdRef = useRef(0);
   const {
+    clearErrors,
     control,
     handleSubmit,
+    setError,
     watch,
     formState: { errors, isValid },
   } = useForm<OnboardingFormData>({
@@ -17,12 +26,68 @@ export function useOnboardingForm() {
   });
 
   const nicknameValue = watch("nickname");
-  const errorMessage = errors.nickname?.message;
+  const nicknameError = errors.nickname;
+  const errorMessage = nicknameError?.message;
+  const hasNicknameFormatError = Boolean(nicknameError && nicknameError.type !== "server");
+
+  useEffect(() => {
+    if (!nicknameValue || hasNicknameFormatError) {
+      latestCheckIdRef.current += 1;
+      setIsCheckingNickname(false);
+      return;
+    }
+
+    const checkId = latestCheckIdRef.current + 1;
+    latestCheckIdRef.current = checkId;
+    setIsCheckingNickname(true);
+
+    // Debouncing을 위한 timer
+    const timeoutId = window.setTimeout(async () => {
+      const result = await checkNicknameAction(nicknameValue);
+
+      // 마지막 요청이 아닐 경우 중지한다.
+      if (latestCheckIdRef.current !== checkId) {
+        return;
+      }
+
+      setIsCheckingNickname(false);
+
+      // type: "server"는 실제 API 요청 후, 서버에서 받은 에러를 나타낸다.
+      if (!result.success) {
+        setError("nickname", {
+          type: "server",
+          message: getNicknameCheckErrorMessage(result.error.data),
+        });
+        return;
+      }
+
+      if (!result.data.isAvailable) {
+        setError("nickname", {
+          type: "server",
+          message: "중복된 닉네임입니다.",
+        });
+        return;
+      }
+
+      clearErrors("nickname");
+    }, NICKNAME_CHECK_DELAY_MS);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [clearErrors, hasNicknameFormatError, nicknameValue, setError]);
 
   const getHelperState = () => {
     if (!nicknameValue) {
       return {
         helperText: "한글 및 영문, 숫자 최대 20자까지 입력할 수 있어요.",
+        tone: "default" as const,
+      };
+    }
+
+    if (isCheckingNickname) {
+      return {
+        helperText: "닉네임 중복 확인 중입니다.",
         tone: "default" as const,
       };
     }
@@ -49,7 +114,9 @@ export function useOnboardingForm() {
   return {
     control,
     handleSubmit,
+    isCheckingNickname,
     isValid,
+    setError,
     ...getHelperState(),
   };
 }

--- a/src/features/onboarding/hooks/use-onboarding-form.hook.ts
+++ b/src/features/onboarding/hooks/use-onboarding-form.hook.ts
@@ -39,10 +39,11 @@ export function useOnboardingForm() {
 
     const checkId = latestCheckIdRef.current + 1;
     latestCheckIdRef.current = checkId;
-    setIsCheckingNickname(true);
 
     // Debouncing을 위한 timer
     const timeoutId = window.setTimeout(async () => {
+      setIsCheckingNickname(true);
+
       const result = await checkNicknameAction(nicknameValue);
 
       // 마지막 요청이 아닐 경우 중지한다.

--- a/src/features/onboarding/hooks/use-onboarding-form.hook.ts
+++ b/src/features/onboarding/hooks/use-onboarding-form.hook.ts
@@ -16,7 +16,7 @@ export function useOnboardingForm() {
     handleSubmit,
     setError,
     watch,
-    formState: { errors, isValid },
+    formState: { errors, isSubmitting, isValid },
   } = useForm<OnboardingFormData>({
     resolver: zodResolver(onboardingSchema),
     defaultValues: {
@@ -115,6 +115,7 @@ export function useOnboardingForm() {
     control,
     handleSubmit,
     isCheckingNickname,
+    isSubmitting,
     isValid,
     setError,
     ...getHelperState(),

--- a/src/features/onboarding/models/onboarding.schema.ts
+++ b/src/features/onboarding/models/onboarding.schema.ts
@@ -1,8 +1,5 @@
 import { z } from "zod";
 
-// TODO: 서버 닉네임 중복 검증 API 연동 전까지 사용하는 UI 검증용 mock
-export const ALREADY_USED_NICKNAMES = new Set(["호구", "admin", "test"]);
-
 export const onboardingSchema = z.object({
   nickname: z
     .string()
@@ -12,10 +9,7 @@ export const onboardingSchema = z.object({
     .min(2, "2자 이상 20자 이하의 한글, 영문, 숫자만 사용해주세요.")
     .max(20, "2자 이상 20자 이하의 한글, 영문, 숫자만 사용해주세요.")
     .regex(/^[a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣ]+$/, "특수문자는 입력할 수 없습니다.")
-    .regex(/^[a-zA-Z0-9가-힣]+$/, "단어 또는 문장 형태로 입력해주세요.")
-    .refine((val) => !ALREADY_USED_NICKNAMES.has(val), {
-      message: "중복된 닉네임입니다.",
-    }),
+    .regex(/^[a-zA-Z0-9가-힣]+$/, "단어 또는 문장 형태로 입력해주세요."),
 });
 
 export type OnboardingFormData = z.infer<typeof onboardingSchema>;

--- a/src/features/onboarding/utils/index.ts
+++ b/src/features/onboarding/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./onboarding-error-message.utils";

--- a/src/features/onboarding/utils/onboarding-error-message.utils.ts
+++ b/src/features/onboarding/utils/onboarding-error-message.utils.ts
@@ -6,15 +6,11 @@ const nicknameFieldErrorMessages: Record<string, string> = {
   NICKNAME_LENGTH_EXCEEDED: "2자 이상 20자 이하의 한글, 영문, 숫자만 사용해주세요.",
 };
 
-/**
- * API 실패 응답 데이터가 백엔드 공통 에러 응답 형태인지 확인한다.
- *
- * @param data - API 실패 시 `ApiError.data`에 담긴 원본 응답 데이터
- * @returns `code` 필드를 가진 백엔드 에러 응답이면 `true`
- */
-function isErrorResponse(data: unknown): data is ErrorResponse {
-  return data !== null && typeof data === "object" && "code" in data && typeof data.code === "string";
-}
+const onboardingSubmitErrorMessages: Record<string, string> = {
+  EMPTY_REGISTER_TOKEN: "가입 인증 정보가 없습니다. 다시 로그인해주세요.",
+  REGISTER_TOKEN_EXPIRED: "가입 인증 시간이 만료되었습니다. 다시 로그인해주세요.",
+  INVALID_REGISTER_TOKEN: "가입 인증 정보가 올바르지 않습니다. 다시 로그인해주세요.",
+};
 
 /**
  * 닉네임 중복 확인 API의 실패 응답을 온보딩 입력 필드에 표시할 메시지로 변환한다.
@@ -22,19 +18,61 @@ function isErrorResponse(data: unknown): data is ErrorResponse {
  * 서버가 명세의 `ErrorResponse.errors`로 닉네임 필드 오류 코드를 내려주면
  * 해당 코드를 사용자 안내 문구로 매핑하고, 알 수 없는 형태의 응답이면 기본 실패 문구를 반환한다.
  *
- * @param data - 닉네임 중복 확인 API 실패 시 받은 원본 응답 데이터
+ * @param errorResponse - 닉네임 중복 확인 API 실패 응답
  * @returns 온보딩 닉네임 입력 필드에 표시할 에러 메시지
  */
-export function getNicknameCheckErrorMessage(data: unknown) {
-  if (!isErrorResponse(data)) {
+export function getNicknameCheckErrorMessage(errorResponse?: ErrorResponse) {
+  if (!errorResponse) {
     return "닉네임 중복 확인에 실패했습니다.";
   }
 
-  const nicknameErrorCode = data.errors?.find((error) => error.field === "nickname")?.code;
+  const nicknameErrorCode = errorResponse.errors?.find((error) => error.field === "nickname")?.code;
 
   if (!nicknameErrorCode) {
     return "닉네임 중복 확인에 실패했습니다.";
   }
 
   return nicknameFieldErrorMessages[nicknameErrorCode] ?? "닉네임 중복 확인에 실패했습니다.";
+}
+
+/**
+ * 온보딩 회원 생성 API 실패 응답 중 닉네임 필드에 표시할 메시지로 변환한다.
+ *
+ * 서버가 `DUPLICATE_NICKNAME` 또는 닉네임 필드 유효성 오류를 내려주면
+ * 온보딩 입력 필드 에러로 표시할 메시지를 반환하고, 필드 에러가 아니면 `undefined`를 반환한다.
+ *
+ * @param errorResponse - 온보딩 회원 생성 API 실패 응답
+ * @returns 닉네임 입력 필드에 표시할 메시지 또는 필드 에러가 아닐 때 `undefined`
+ */
+export function getOnboardingNicknameErrorMessage(errorResponse?: ErrorResponse) {
+  if (!errorResponse) {
+    return undefined;
+  }
+
+  if (errorResponse.code === "DUPLICATE_NICKNAME") {
+    return "중복된 닉네임입니다.";
+  }
+
+  const nicknameErrorCode = errorResponse.errors?.find((error) => error.field === "nickname")?.code;
+
+  return nicknameErrorCode ? nicknameFieldErrorMessages[nicknameErrorCode] : undefined;
+}
+
+/**
+ * 온보딩 회원 생성 API 실패 응답을 제출 영역에 표시할 메시지로 변환한다.
+ *
+ * registerToken 관련 인증 오류는 사용자에게 다시 로그인해야 함을 안내하고,
+ * 알 수 없는 응답은 일반 실패 문구로 변환한다.
+ *
+ * @param errorResponse - 온보딩 회원 생성 API 실패 응답
+ * @returns 온보딩 제출 영역에 표시할 에러 메시지
+ */
+export function getOnboardingSubmitErrorMessage(errorResponse?: ErrorResponse) {
+  if (!errorResponse) {
+    return "온보딩을 완료하지 못했습니다. 잠시 후 다시 시도해주세요.";
+  }
+
+  return (
+    onboardingSubmitErrorMessages[errorResponse.code] ?? "온보딩을 완료하지 못했습니다. 잠시 후 다시 시도해주세요."
+  );
 }

--- a/src/features/onboarding/utils/onboarding-error-message.utils.ts
+++ b/src/features/onboarding/utils/onboarding-error-message.utils.ts
@@ -1,0 +1,40 @@
+import type { ErrorResponse } from "@/shared/api/generated";
+
+const nicknameFieldErrorMessages: Record<string, string> = {
+  EMPTY_NICKNAME: "닉네임을 입력해주세요.",
+  SPECIAL_CHAR_NICKNAME: "특수문자는 입력할 수 없습니다.",
+  NICKNAME_LENGTH_EXCEEDED: "2자 이상 20자 이하의 한글, 영문, 숫자만 사용해주세요.",
+};
+
+/**
+ * API 실패 응답 데이터가 백엔드 공통 에러 응답 형태인지 확인한다.
+ *
+ * @param data - API 실패 시 `ApiError.data`에 담긴 원본 응답 데이터
+ * @returns `code` 필드를 가진 백엔드 에러 응답이면 `true`
+ */
+function isErrorResponse(data: unknown): data is ErrorResponse {
+  return data !== null && typeof data === "object" && "code" in data && typeof data.code === "string";
+}
+
+/**
+ * 닉네임 중복 확인 API의 실패 응답을 온보딩 입력 필드에 표시할 메시지로 변환한다.
+ *
+ * 서버가 명세의 `ErrorResponse.errors`로 닉네임 필드 오류 코드를 내려주면
+ * 해당 코드를 사용자 안내 문구로 매핑하고, 알 수 없는 형태의 응답이면 기본 실패 문구를 반환한다.
+ *
+ * @param data - 닉네임 중복 확인 API 실패 시 받은 원본 응답 데이터
+ * @returns 온보딩 닉네임 입력 필드에 표시할 에러 메시지
+ */
+export function getNicknameCheckErrorMessage(data: unknown) {
+  if (!isErrorResponse(data)) {
+    return "닉네임 중복 확인에 실패했습니다.";
+  }
+
+  const nicknameErrorCode = data.errors?.find((error) => error.field === "nickname")?.code;
+
+  if (!nicknameErrorCode) {
+    return "닉네임 중복 확인에 실패했습니다.";
+  }
+
+  return nicknameFieldErrorMessages[nicknameErrorCode] ?? "닉네임 중복 확인에 실패했습니다.";
+}

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -1,4 +1,5 @@
 import { ApiError } from "./error";
+import type { ErrorResponse } from "./generated";
 
 const DEFAULT_API_TIMEOUT_MS = 15_000;
 
@@ -75,7 +76,7 @@ export async function apiClient<T>(path: string, options: ApiClientOptions = {})
       throw new ApiError({
         status: response.status,
         message: getErrorMessage(data, response.statusText),
-        data,
+        data: data as ErrorResponse,
       });
     }
 

--- a/src/shared/api/error.ts
+++ b/src/shared/api/error.ts
@@ -3,15 +3,17 @@
 // 이 파일의 `ApiError`는 400/401/404/500, timeout 같은 API 응답 실패를
 // TanStack Query나 server action에서 다루기 위한 데이터 계층 에러입니다.
 
+import type { ErrorResponse } from "@/shared/api/generated";
+
 export type ApiErrorPayload = {
   status?: number;
   message: string;
-  data?: unknown;
+  data?: ErrorResponse;
 };
 
 export class ApiError extends Error {
   status?: number;
-  data?: unknown;
+  data?: ErrorResponse;
 
   constructor(payload: ApiErrorPayload) {
     super(payload.message);


### PR DESCRIPTION
## 📋 변경 사항

온보딩 화면에서 닉네임 중복 확인 및 회원 생성 API를 연동했습니다.

- 닉네임 mock 중복 검사 제거
- 닉네임 입력 debounce 기반 중복 확인 API 연동
- 온보딩 회원 생성 API 연동
- `registerToken` 쿠키 전달을 위한 `/api/users` 프록시 라우트 추가
- 서버 실패 응답을 `ErrorResponse` 기준으로 처리하도록 공통 API 에러 타입 정리
- 닉네임/온보딩 제출 에러 메시지 변환 유틸 함수 추가

## 🏷️ PR 유형

- [x] 🚀 feat: 새로운 기능 추가
- [x] ♻️ refactor: 코드 리팩토링
- [ ] 🐛 fix: 버그 수정
- [ ] 📝 docs: 문서 수정
- [ ] ✅ test: 테스트 코드 추가/수정
- [ ] 🔧 chore: 빌드/패키지 매니저 수정

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션 준수
- [x] 로컬 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📸 테스트 결과
- 닉네임 중복 확인, 온보딩 완료 후 홈으로 리다이렉트 모두 정상 동작

## 🔗 관련 이슈

- Closes #37