### PR TITLE
feat: 게시글 상세 및 댓글 API 연동

### DIFF
--- a/src/app/post/[postId]/_components/post-detail.client.tsx
+++ b/src/app/post/[postId]/_components/post-detail.client.tsx
@@ -1,15 +1,22 @@
 "use client";
 
-import { getPrimaryPostCategoryLabel, POST_DETAIL_RESPONSE_MOCKS } from "@/features/post/model";
-import { createDetailVoteOptions, DETAIL_COMMENTS_MOCK } from "@/features/post/model/post-detail.mock";
+import { useRouter } from "next/navigation";
+import { useMemo } from "react";
+import SmileyXEyesIcon from "@/assets/icons/smiley-x-eyes.svg";
+import { useDeletePostMutation, usePostDetailQuery } from "@/features/post/api";
+import { POST_CATEGORY_VALUES, toPostCategoryLabel } from "@/features/post/constants";
+import { usePostDetailBookmarkState, usePostDetailComments } from "@/features/post/hooks";
 import {
   PostCommentsSection,
   PostDetailCard,
   PostDetailContent,
   PostDetailHeader,
+  type PostVoteOption,
   PostVoteSection,
 } from "@/features/post/ui";
-import { ContentCardCarousel } from "@/shared/ui";
+import { isApiError } from "@/shared/api";
+import type { PostDetailResponse } from "@/shared/api/generated";
+import { Button, ContentCardCarousel, EmptyState, LoadingState } from "@/shared/ui";
 import { formatNumber, formatRelativeTime } from "@/shared/utils/format";
 import { HeaderWidget } from "@/widgets/header/ui";
 
@@ -17,21 +24,148 @@ type PostDetailPageClientProps = {
   postId: number;
 };
 
+function createVoteOptions(vote: PostDetailResponse["vote"]): PostVoteOption[] {
+  const totalVotes = vote.totalVotes || 0;
+  const calculatePercent = (count: number) => (totalVotes > 0 ? Math.round((count / totalVotes) * 100) : 0);
+
+  return [
+    {
+      id: "HOGU",
+      label: "호구 맞다",
+      emoji: "😢",
+      percent: calculatePercent(vote.yesVotes),
+    },
+    {
+      id: "NOT_HOGU",
+      label: "아니다",
+      emoji: "🤔",
+      percent: calculatePercent(vote.noVotes),
+    },
+  ];
+}
+
+function getPrimaryCategoryLabel(post: Pick<PostDetailResponse, "categories">) {
+  const category = post.categories.find((value) => POST_CATEGORY_VALUES.includes(value)) ?? "ETC";
+  return toPostCategoryLabel(category);
+}
+
+function createImageCarouselItems(post: Pick<PostDetailResponse, "postId" | "images" | "title">) {
+  return post.images.map((imageUrl, index) => ({
+    id: `${post.postId}-image-${index + 1}`,
+    content: (
+      // biome-ignore lint/performance/noImgElement: 외부 이미지 도메인 정책의 경우, 추후 이미지 연동 이슈에서 정리될 예정
+      <img
+        src={imageUrl}
+        alt={`${post.title} 첨부 이미지 ${index + 1}`}
+        className="h-[196px] w-full rounded-[8px] object-cover"
+      />
+    ),
+  }));
+}
+
+function PostDetailErrorState({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="flex min-h-[calc(100dvh-60px)] flex-col justify-center">
+      <EmptyState
+        layout="inline"
+        icon={<SmileyXEyesIcon aria-hidden className="size-20 text-text-03" />}
+        title={"게시글을 불러오지 못했습니다.\n잠시 후 다시 시도해주세요."}
+        action={
+          <Button type="button" fullWidth onClick={onRetry}>
+            다시 시도
+          </Button>
+        }
+      />
+    </div>
+  );
+}
+
+function PostDetailNotFoundState() {
+  return (
+    <div className="flex min-h-[calc(100dvh-60px)] flex-col justify-center">
+      <EmptyState
+        layout="inline"
+        icon={<SmileyXEyesIcon aria-hidden className="size-20 text-text-03" />}
+        title={"게시글을 찾을 수 없습니다.\n삭제되었거나 이동된 게시글입니다."}
+      />
+    </div>
+  );
+}
+
 export default function PostDetailPageClient({ postId }: PostDetailPageClientProps) {
-  const selectedPost = POST_DETAIL_RESPONSE_MOCKS.find((post) => post.postId === postId);
-  if (!selectedPost) {
-    throw new Error(`Post not found for postId=${postId}`);
+  const router = useRouter();
+  const postDetailQuery = usePostDetailQuery(postId);
+  const deletePostMutation = useDeletePostMutation(postId);
+  const post = postDetailQuery.data;
+  const voteOptions = useMemo(() => (post ? createVoteOptions(post.vote) : []), [post]);
+  const imageCarouselItems = useMemo(() => (post ? createImageCarouselItems(post) : []), [post]);
+  const initialSelectedVoteId =
+    post?.vote.myVote === "HOGU" || post?.vote.myVote === "NOT_HOGU" ? post.vote.myVote : undefined;
+
+  const handleAuthRequiredError = (error: unknown) => {
+    if (isApiError(error) && error.status === 401) {
+      router.replace("/login?errorCode=AUTH_REQUIRED");
+      return true;
+    }
+
+    return false;
+  };
+  const bookmarkState = usePostDetailBookmarkState({
+    postId,
+    post,
+    onAuthRequired: handleAuthRequiredError,
+  });
+  const commentsState = usePostDetailComments({
+    postId,
+    onAuthRequired: handleAuthRequiredError,
+  });
+
+  const handleDeletePost = async () => {
+    try {
+      await deletePostMutation.mutateAsync();
+      router.replace("/");
+    } catch (error) {
+      if (!handleAuthRequiredError(error)) {
+        throw error;
+      }
+    }
+  };
+
+  if (postDetailQuery.isPending) {
+    return (
+      <div className="flex min-h-full flex-col">
+        <HeaderWidget title="게시글 상세" />
+        <LoadingState />
+      </div>
+    );
   }
 
-  const voteOptions = createDetailVoteOptions();
-  const initialSelectedVoteId =
-    selectedPost.vote.myVote === "HOGU" || selectedPost.vote.myVote === "NOT_HOGU"
-      ? selectedPost.vote.myVote
-      : undefined;
-  const imageCarouselItems = selectedPost.images.map((gradientClassName, index) => ({
-    id: `${selectedPost.postId}-image-${index + 1}`,
-    content: <div className={`h-[196px] w-full rounded-[8px] bg-gradient-to-br ${gradientClassName}`} />,
-  }));
+  if (postDetailQuery.isError) {
+    if (isApiError(postDetailQuery.error) && postDetailQuery.error.status === 404) {
+      return (
+        <div className="flex min-h-full flex-col">
+          <HeaderWidget title="게시글 상세" />
+          <PostDetailNotFoundState />
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex min-h-full flex-col">
+        <HeaderWidget title="게시글 상세" />
+        <PostDetailErrorState onRetry={() => postDetailQuery.refetch()} />
+      </div>
+    );
+  }
+
+  if (!post) {
+    return (
+      <div className="flex min-h-full flex-col">
+        <HeaderWidget title="게시글 상세" />
+        <PostDetailNotFoundState />
+      </div>
+    );
+  }
 
   return (
     <div className="flex min-h-full flex-col">
@@ -39,36 +173,61 @@ export default function PostDetailPageClient({ postId }: PostDetailPageClientPro
       <main className="flex-1 px-common-padding py-6">
         <PostDetailCard>
           <PostDetailHeader
-            postId={selectedPost.postId}
-            category={getPrimaryPostCategoryLabel(selectedPost)}
-            meta={formatRelativeTime(selectedPost.createdAt)}
-            viewCount={selectedPost.viewCount}
-            isBookmarked={false}
-            isMine={selectedPost.isMine}
+            postId={post.postId}
+            category={getPrimaryCategoryLabel(post)}
+            meta={formatRelativeTime(post.createdAt)}
+            viewCount={post.viewCount}
+            isBookmarked={bookmarkState.isBookmarked}
+            isMine={post.isMine}
+            isDeleting={deletePostMutation.isPending}
+            isBookmarking={bookmarkState.isBookmarking}
+            onBookmarkToggle={bookmarkState.handleToggleBookmark}
+            onDelete={handleDeletePost}
           />
           <PostDetailContent
-            title={selectedPost.title}
-            authorName={selectedPost.writer.nickname}
-            content={selectedPost.content}
+            title={post.title}
+            authorName={post.writer.nickname}
+            authorImage={post.writer.profileImageUrl ?? undefined}
+            content={post.content}
             media={
-              <ContentCardCarousel
-                items={imageCarouselItems}
-                className="gap-0 px-0 pb-0"
-                showPagination
-                paginationClassName="bottom-4"
-              />
+              imageCarouselItems.length > 0 ? (
+                <ContentCardCarousel
+                  items={imageCarouselItems}
+                  className="gap-0 px-0 pb-0"
+                  showPagination
+                  paginationClassName="bottom-4"
+                />
+              ) : null
             }
             mediaContainerClassName="rounded-[8px] bg-bg-02"
           />
           <PostVoteSection
             options={voteOptions}
-            totalVotes={selectedPost.vote.totalVotes}
+            totalVotes={post.vote.totalVotes}
             initialSelectedId={initialSelectedVoteId}
-            aria-label={`판결 참여 ${formatNumber(selectedPost.vote.totalVotes)}명`}
+            aria-label={`판결 참여 ${formatNumber(post.vote.totalVotes)}명`}
           />
         </PostDetailCard>
 
-        <PostCommentsSection className="mt-16" commentsResponse={DETAIL_COMMENTS_MOCK} />
+        {commentsState.commentsQuery.isError ? (
+          <PostDetailErrorState onRetry={() => commentsState.commentsQuery.refetch()} />
+        ) : (
+          <PostCommentsSection
+            className="mt-16"
+            commentsResponse={commentsState.commentsResponse}
+            sortValue={commentsState.commentSortValue}
+            onSortChange={commentsState.setCommentSortValue}
+            onCreateComment={commentsState.handleCreateComment}
+            onCreateReply={commentsState.handleCreateReply}
+            onUpdateComment={commentsState.handleUpdateComment}
+            onDeleteComment={commentsState.handleDeleteComment}
+            onToggleHelpful={commentsState.handleToggleCommentHelpful}
+            isCreatingComment={commentsState.isCreatingComment}
+            hasNextPage={Boolean(commentsState.commentsQuery.hasNextPage)}
+            isFetchingNextPage={commentsState.commentsQuery.isFetchingNextPage}
+            onLoadMore={commentsState.handleLoadMoreComments}
+          />
+        )}
       </main>
     </div>
   );

--- a/src/app/post/[postId]/page.tsx
+++ b/src/app/post/[postId]/page.tsx
@@ -1,44 +1,56 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { POST_DETAIL_RESPONSE_MOCKS } from "@/features/post/model";
+import { getPostDetail } from "@/features/post/api";
+import { isApiError } from "@/shared/api";
 import PostDetailPageClient from "./_components/post-detail.client";
 
-function resolvePost(postId: string) {
+function parsePostId(postId: string) {
   const numericPostId = Number(postId);
-  if (!Number.isFinite(numericPostId)) {
+  if (!Number.isInteger(numericPostId) || numericPostId <= 0) {
     return null;
   }
 
-  return POST_DETAIL_RESPONSE_MOCKS.find((item) => item.postId === numericPostId) ?? null;
+  return numericPostId;
 }
 
 export async function generateMetadata({ params }: { params: Promise<{ postId: string }> }): Promise<Metadata> {
   const { postId } = await params;
-  const post = resolvePost(postId);
-  if (!post) {
+  const numericPostId = parsePostId(postId);
+  if (!numericPostId) {
     notFound();
   }
 
-  // TODO: Cypress 도입 시 /post/[postId] 메타 회귀 테스트 추가 필요
-  // - 각 값이 title/description/openGraph 게시글 데이터와 일치하는지 +
-  //  링크 미리보기(언펄)에서 의도한대로 제목/설명 제대로 노출되는지 크로스체크할 것
-  return {
-    title: post.title,
-    description: post.content,
-    openGraph: {
+  try {
+    const post = await getPostDetail(numericPostId);
+
+    // TODO: Cypress 도입 시 /post/[postId] 메타 회귀 테스트 추가 필요
+    // - 각 값이 title/description/openGraph 게시글 데이터와 일치하는지 +
+    //  링크 미리보기(언펄)에서 의도한대로 제목/설명 제대로 노출되는지 크로스체크할 것
+    // TODO: 상세 화면 클라이언트 조회와 metadata 조회가 중복되어 호출 비용 이슈가 있을 수 있어 추후 논의 필요
+    return {
       title: post.title,
       description: post.content,
-      type: "article",
-    },
-  };
+      openGraph: {
+        title: post.title,
+        description: post.content,
+        type: "article",
+      },
+    };
+  } catch (error) {
+    if (isApiError(error) && error.status === 404) {
+      notFound();
+    }
+
+    throw error;
+  }
 }
 
 export default async function PostDetailPage({ params }: { params: Promise<{ postId: string }> }) {
   const { postId } = await params;
-  const post = resolvePost(postId);
-  if (!post) {
+  const numericPostId = parsePostId(postId);
+  if (!numericPostId) {
     notFound();
   }
 
-  return <PostDetailPageClient postId={post.postId} />;
+  return <PostDetailPageClient postId={numericPostId} />;
 }

--- a/src/features/post/api/post.action.ts
+++ b/src/features/post/api/post.action.ts
@@ -1,17 +1,29 @@
 "use server";
 
 import { type ApiResult, apiFailure, apiSuccess } from "@/shared/api";
+import type { CommentReadResponse, HomePostListResponse, PostDetailResponse } from "@/shared/api/generated";
 import {
+  type GetCommentsParams,
   type GetHomePostsParams,
+  getComments,
   getHomePosts,
   getPostDetail,
-  type HomePostsResponse,
-  type PostDetailResponse,
 } from "./post.service";
 
-export async function getHomePostsAction(params: GetHomePostsParams = {}): Promise<ApiResult<HomePostsResponse>> {
+export async function getHomePostsAction(params: GetHomePostsParams = {}): Promise<ApiResult<HomePostListResponse>> {
   try {
     return apiSuccess(await getHomePosts(params));
+  } catch (error) {
+    return apiFailure(error);
+  }
+}
+
+export async function getCommentsAction(
+  postId: number,
+  params: GetCommentsParams = {},
+): Promise<ApiResult<CommentReadResponse>> {
+  try {
+    return apiSuccess(await getComments(postId, params));
   } catch (error) {
     return apiFailure(error);
   }

--- a/src/features/post/api/post.client-service.ts
+++ b/src/features/post/api/post.client-service.ts
@@ -1,10 +1,69 @@
 "use client";
 
 import { authenticatedApiClient } from "@/features/auth/api";
-import type { DeleteBookmarkPath, PostBookmarkResponse } from "@/shared/api/generated";
+import type {
+  CommentCreateRequest,
+  CommentCreateResponse,
+  CommentHelpfulResponse,
+  CommentUpdateRequest,
+  CommentUpdateResponse,
+  CreateBookmarkPath,
+  CreateCommentHelpfulPath,
+  CreateCommentPath,
+  DeleteBookmarkPath,
+  DeleteCommentHelpfulPath,
+  DeleteCommentPath,
+  DeletePostPath,
+  PostBookmarkResponse,
+  UpdateCommentPath,
+} from "@/shared/api/generated";
+
+export async function createBookmarkWithAuth({ postId }: CreateBookmarkPath) {
+  return authenticatedApiClient<PostBookmarkResponse>(`/api/posts/${postId}/bookmarks`, {
+    method: "POST",
+  });
+}
 
 export async function deleteBookmarkWithAuth({ postId }: DeleteBookmarkPath) {
   return authenticatedApiClient<PostBookmarkResponse>(`/api/posts/${postId}/bookmarks`, {
+    method: "DELETE",
+  });
+}
+
+export async function deletePostWithAuth({ postId }: DeletePostPath) {
+  return authenticatedApiClient<void>(`/api/posts/${postId}`, {
+    method: "DELETE",
+  });
+}
+
+export async function createCommentWithAuth({ postId }: CreateCommentPath, request: CommentCreateRequest) {
+  return authenticatedApiClient<CommentCreateResponse>(`/api/posts/${postId}/comments`, {
+    method: "POST",
+    body: request,
+  });
+}
+
+export async function updateCommentWithAuth({ postId, commentId }: UpdateCommentPath, request: CommentUpdateRequest) {
+  return authenticatedApiClient<CommentUpdateResponse>(`/api/posts/${postId}/comments/${commentId}`, {
+    method: "PATCH",
+    body: request,
+  });
+}
+
+export async function deleteCommentWithAuth({ postId, commentId }: DeleteCommentPath) {
+  return authenticatedApiClient<void>(`/api/posts/${postId}/comments/${commentId}`, {
+    method: "DELETE",
+  });
+}
+
+export async function createCommentHelpfulWithAuth({ postId, commentId }: CreateCommentHelpfulPath) {
+  return authenticatedApiClient<CommentHelpfulResponse>(`/api/posts/${postId}/comments/${commentId}/helpful`, {
+    method: "POST",
+  });
+}
+
+export async function deleteCommentHelpfulWithAuth({ postId, commentId }: DeleteCommentHelpfulPath) {
+  return authenticatedApiClient<CommentHelpfulResponse>(`/api/posts/${postId}/comments/${commentId}/helpful`, {
     method: "DELETE",
   });
 }

--- a/src/features/post/api/post.keys.ts
+++ b/src/features/post/api/post.keys.ts
@@ -1,3 +1,13 @@
 import { createDomainQueryKeys } from "@/shared/api";
+import type { GetCommentsParams } from "./post.service";
 
-export const postQueryKeys = createDomainQueryKeys("posts");
+const basePostQueryKeys = createDomainQueryKeys("posts");
+
+export const postQueryKeys = {
+  ...basePostQueryKeys,
+  commentsRoot: (postId: string | number) => [...basePostQueryKeys.detail(postId), "comments"] as const,
+  comments: (postId: string | number, params: GetCommentsParams = {}) =>
+    [...basePostQueryKeys.detail(postId), "comments", params] as const,
+  commentsInfinite: (postId: string | number, params: Omit<GetCommentsParams, "cursor"> = {}) =>
+    [...basePostQueryKeys.detail(postId), "comments", "infinite", params] as const,
+};

--- a/src/features/post/api/post.query.ts
+++ b/src/features/post/api/post.query.ts
@@ -1,10 +1,21 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { unwrapApiResult } from "@/shared/api";
-import { getHomePostsAction, getPostDetailAction } from "./post.action";
+import type { CommentItemResponse } from "@/shared/api/generated";
+import { getCommentsAction, getHomePostsAction, getPostDetailAction } from "./post.action";
+import {
+  createBookmarkWithAuth,
+  createCommentHelpfulWithAuth,
+  createCommentWithAuth,
+  deleteBookmarkWithAuth,
+  deleteCommentHelpfulWithAuth,
+  deleteCommentWithAuth,
+  deletePostWithAuth,
+  updateCommentWithAuth,
+} from "./post.client-service";
 import { postQueryKeys } from "./post.keys";
-import type { GetHomePostsParams } from "./post.service";
+import type { GetCommentsParams, GetHomePostsParams } from "./post.service";
 
 export function useHomePostsQuery(params: GetHomePostsParams = {}) {
   return useQuery({
@@ -13,10 +24,120 @@ export function useHomePostsQuery(params: GetHomePostsParams = {}) {
   });
 }
 
+export function useHomePostsInfiniteQuery(params: Omit<GetHomePostsParams, "cursor"> = {}) {
+  return useInfiniteQuery({
+    queryKey: postQueryKeys.list(params),
+    queryFn: ({ pageParam }) =>
+      getHomePostsAction({
+        ...params,
+        cursor: pageParam,
+      }).then(unwrapApiResult),
+    initialPageParam: null as string | null,
+    getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.nextCursor : undefined),
+  });
+}
+
 export function usePostDetailQuery(postId: number) {
   return useQuery({
     queryKey: postQueryKeys.detail(postId),
     queryFn: () => getPostDetailAction(postId).then(unwrapApiResult),
     enabled: Number.isFinite(postId),
+  });
+}
+
+export function useCommentsQuery(postId: number, params: GetCommentsParams = {}) {
+  return useQuery({
+    queryKey: postQueryKeys.comments(postId, params),
+    queryFn: () => getCommentsAction(postId, params).then(unwrapApiResult),
+    enabled: Number.isFinite(postId),
+  });
+}
+
+export function useCommentsInfiniteQuery(postId: number, params: Omit<GetCommentsParams, "cursor"> = {}) {
+  return useInfiniteQuery({
+    queryKey: postQueryKeys.commentsInfinite(postId, params),
+    queryFn: ({ pageParam }) =>
+      getCommentsAction(postId, {
+        ...params,
+        cursor: pageParam,
+      }).then(unwrapApiResult),
+    initialPageParam: null as string | null,
+    getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.nextCursor : undefined),
+    enabled: Number.isFinite(postId),
+  });
+}
+
+export function useDeletePostMutation(postId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => deletePostWithAuth({ postId }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: postQueryKeys.all });
+    },
+  });
+}
+
+export function useTogglePostBookmarkMutation(postId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (isBookmarked: boolean) =>
+      isBookmarked ? deleteBookmarkWithAuth({ postId }) : createBookmarkWithAuth({ postId }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: postQueryKeys.detail(postId) });
+      queryClient.invalidateQueries({ queryKey: postQueryKeys.lists() });
+    },
+  });
+}
+
+export function useCreateCommentMutation(postId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ parentId, content }: { parentId: number | null; content: string }) =>
+      createCommentWithAuth({ postId }, { parentId, content }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: postQueryKeys.commentsRoot(postId) });
+      queryClient.invalidateQueries({ queryKey: postQueryKeys.detail(postId) });
+    },
+  });
+}
+
+export function useUpdateCommentMutation(postId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ commentId, content }: { commentId: number; content: string }) =>
+      updateCommentWithAuth({ postId, commentId }, { content }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: postQueryKeys.commentsRoot(postId) });
+    },
+  });
+}
+
+export function useDeleteCommentMutation(postId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (commentId: number) => deleteCommentWithAuth({ postId, commentId }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: postQueryKeys.commentsRoot(postId) });
+      queryClient.invalidateQueries({ queryKey: postQueryKeys.detail(postId) });
+    },
+  });
+}
+
+export function useToggleCommentHelpfulMutation(postId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (comment: Pick<CommentItemResponse, "commentId" | "isHelpful">) =>
+      comment.isHelpful
+        ? deleteCommentHelpfulWithAuth({ postId, commentId: comment.commentId })
+        : createCommentHelpfulWithAuth({ postId, commentId: comment.commentId }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: postQueryKeys.commentsRoot(postId) });
+    },
   });
 }

--- a/src/features/post/api/post.service.ts
+++ b/src/features/post/api/post.service.ts
@@ -1,25 +1,31 @@
 import { apiClient } from "@/shared/api";
+import type {
+  CommentReadResponse,
+  GetCommentsQuery,
+  GetHomePostsQuery,
+  HomePostListResponse,
+  PostDetailResponse,
+} from "@/shared/api/generated";
 
-export type GetHomePostsParams = {
-  keyword?: string;
-  categories?: string;
-  sortBy?: string;
-  pageSize?: number;
-  cursor?: string;
-};
-
-export type HomePostsResponse = unknown;
-export type PostDetailResponse = unknown;
+export type GetHomePostsParams = GetHomePostsQuery;
+export type GetCommentsParams = GetCommentsQuery;
 
 export async function getHomePosts(params: GetHomePostsParams = {}) {
-  return apiClient<HomePostsResponse>("/posts", {
+  return apiClient<HomePostListResponse>("/api/posts", {
     method: "GET",
     query: params,
   });
 }
 
 export async function getPostDetail(postId: number) {
-  return apiClient<PostDetailResponse>(`/posts/${postId}`, {
+  return apiClient<PostDetailResponse>(`/api/posts/${postId}`, {
     method: "GET",
+  });
+}
+
+export async function getComments(postId: number, params: GetCommentsParams = {}) {
+  return apiClient<CommentReadResponse>(`/api/posts/${postId}/comments`, {
+    method: "GET",
+    query: params,
   });
 }

--- a/src/features/post/hooks/index.ts
+++ b/src/features/post/hooks/index.ts
@@ -1,2 +1,5 @@
+export * from "./use-comment-helpful-state.hook";
+export * from "./use-post-detail-bookmark-state.hook";
+export * from "./use-post-detail-comments.hook";
 export * from "./use-post-write-form.hook";
 export * from "./use-share-post-link.hook";

--- a/src/features/post/hooks/use-comment-helpful-state.hook.ts
+++ b/src/features/post/hooks/use-comment-helpful-state.hook.ts
@@ -1,0 +1,118 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { CommentHelpfulResponse, CommentItemResponse } from "@/shared/api/generated";
+
+type HelpfulState = {
+  active: boolean;
+  count: number;
+};
+
+type UseCommentHelpfulStateParams = {
+  comment: CommentItemResponse;
+  replies: CommentItemResponse[];
+  onToggleHelpful: (comment: CommentItemResponse) => Promise<CommentHelpfulResponse>;
+};
+
+/**
+ * 댓글과 답글의 유익해요 표시 상태와 토글 중복 호출 방지를 관리하는 훅
+ *
+ * @description
+ * 서버에서 다시 내려온 댓글 응답을 기준으로 유익해요 선택 여부와 개수를 동기화합니다.
+ * 원댓글과 답글의 토글 흐름은 같지만, 답글은 여러 개라 `commentId`를 key로 상태를 관리합니다.
+ * API 호출은 사용자가 유익해요 버튼을 누른 시점에만 실행하고, pending 중에는 같은 카드의 중복 호출을 막습니다.
+ *
+ * @param params.comment - 현재 렌더링 중인 원댓글입니다.
+ * @param params.replies - 원댓글에 연결된 답글 목록입니다.
+ * @param params.onToggleHelpful - 유익해요 등록/취소 API 호출 핸들러입니다.
+ *
+ * @returns commentHelpful - 원댓글의 유익해요 선택 여부와 개수입니다.
+ * @returns isCommentHelpfulPending - 원댓글 유익해요 토글 요청 진행 여부입니다.
+ * @returns pendingReplyHelpfulId - 유익해요 토글 요청 중인 답글 ID입니다.
+ * @returns replyHelpfulMap - 답글별 유익해요 선택 여부와 개수입니다.
+ * @returns toggleCommentHelpful - 원댓글 유익해요 토글 핸들러입니다.
+ * @returns toggleReplyHelpful - 답글 유익해요 토글 핸들러입니다.
+ */
+export function useCommentHelpfulState(params: UseCommentHelpfulStateParams) {
+  const { comment, replies, onToggleHelpful } = params;
+  const [commentHelpful, setCommentHelpful] = useState<HelpfulState>({
+    active: comment.isHelpful,
+    count: comment.totalHelpfulCount,
+  });
+  const [isCommentHelpfulPending, setIsCommentHelpfulPending] = useState(false);
+  const [replyHelpfulMap, setReplyHelpfulMap] = useState<Record<number, HelpfulState>>({});
+  const [pendingReplyHelpfulId, setPendingReplyHelpfulId] = useState<number | null>(null);
+
+  useEffect(() => {
+    setCommentHelpful({
+      active: comment.isHelpful,
+      count: comment.totalHelpfulCount,
+    });
+  }, [comment.isHelpful, comment.totalHelpfulCount]);
+
+  useEffect(() => {
+    setReplyHelpfulMap(
+      Object.fromEntries(
+        replies.map((reply) => [reply.commentId, { active: reply.isHelpful, count: reply.totalHelpfulCount }]),
+      ),
+    );
+  }, [replies]);
+
+  const toggleCommentHelpful = async () => {
+    if (isCommentHelpfulPending) {
+      return;
+    }
+
+    setIsCommentHelpfulPending(true);
+    try {
+      const result = await onToggleHelpful({
+        ...comment,
+        isHelpful: commentHelpful.active,
+        totalHelpfulCount: commentHelpful.count,
+      });
+      setCommentHelpful({
+        active: result.isHelpful,
+        count: result.totalHelpfulCount,
+      });
+    } finally {
+      setIsCommentHelpfulPending(false);
+    }
+  };
+
+  const toggleReplyHelpful = async (reply: CommentItemResponse) => {
+    if (pendingReplyHelpfulId !== null) {
+      return;
+    }
+
+    const current = replyHelpfulMap[reply.commentId] ?? {
+      active: reply.isHelpful,
+      count: reply.totalHelpfulCount,
+    };
+    setPendingReplyHelpfulId(reply.commentId);
+    try {
+      const result = await onToggleHelpful({
+        ...reply,
+        isHelpful: current.active,
+        totalHelpfulCount: current.count,
+      });
+      setReplyHelpfulMap((prev) => ({
+        ...prev,
+        [reply.commentId]: {
+          active: result.isHelpful,
+          count: result.totalHelpfulCount,
+        },
+      }));
+    } finally {
+      setPendingReplyHelpfulId(null);
+    }
+  };
+
+  return {
+    commentHelpful,
+    isCommentHelpfulPending,
+    pendingReplyHelpfulId,
+    replyHelpfulMap,
+    toggleCommentHelpful,
+    toggleReplyHelpful,
+  };
+}

--- a/src/features/post/hooks/use-post-detail-bookmark-state.hook.ts
+++ b/src/features/post/hooks/use-post-detail-bookmark-state.hook.ts
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTogglePostBookmarkMutation } from "@/features/post/api";
+import type { PostDetailResponse } from "@/shared/api/generated";
+
+type PostDetailWithBookmark = PostDetailResponse & {
+  isBookmarked?: boolean;
+};
+
+type UsePostDetailBookmarkStateParams = {
+  postId: number;
+  post?: PostDetailResponse;
+  onAuthRequired: (error: unknown) => boolean;
+};
+
+/**
+ * 게시글 상세의 북마크 토글 상태와 낙관적 업데이트를 관리하는 훅
+ *
+ * @description
+ * 북마크 클릭 시 먼저 로컬 상태를 뒤집고, 서버 응답의 `isBookmarked` 값으로 다시 동기화합니다.
+ * 요청 실패 시 이전 상태로 되돌리며, 인증 에러는 호출자가 주입한 로그인 이동 핸들러에 위임합니다.
+ *
+ * @param params.postId - 북마크를 토글할 게시글 ID입니다.
+ * @param params.post - 상세 API 응답입니다.
+ * @param params.onAuthRequired - 인증 필요 에러 처리 핸들러입니다.
+ *
+ * @returns isBookmarked - 현재 북마크 표시 여부입니다.
+ * @returns isBookmarking - 북마크 토글 요청 진행 여부입니다.
+ * @returns handleToggleBookmark - 북마크 토글 핸들러입니다.
+ */
+export function usePostDetailBookmarkState(params: UsePostDetailBookmarkStateParams) {
+  const { postId, post, onAuthRequired } = params;
+  const [isBookmarked, setIsBookmarked] = useState(false);
+  const togglePostBookmarkMutation = useTogglePostBookmarkMutation(postId);
+
+  useEffect(() => {
+    if (!post) {
+      return;
+    }
+
+    // TODO: 현재 백엔드 상세 API 스키마에 isBookmarked 필드가 없어 초기 북마크 상태를 서버 기준으로 동기화할 수 없다.
+    // 상세 응답에 isBookmarked가 추가되면 초기 상태를 서버 응답 기준으로 맞추고, 현재는 클릭 후 PostBookmarkResponse만 로컬에 반영한다.
+    if ("isBookmarked" in post) {
+      setIsBookmarked(Boolean((post as PostDetailWithBookmark).isBookmarked));
+    }
+  }, [post]);
+
+  const handleToggleBookmark = async () => {
+    const previousBookmarked = isBookmarked;
+
+    setIsBookmarked(!previousBookmarked);
+    try {
+      const result = await togglePostBookmarkMutation.mutateAsync(previousBookmarked);
+      setIsBookmarked(result.isBookmarked);
+    } catch (error) {
+      setIsBookmarked(previousBookmarked);
+      if (!onAuthRequired(error)) {
+        throw error;
+      }
+    }
+  };
+
+  return {
+    isBookmarked,
+    isBookmarking: togglePostBookmarkMutation.isPending,
+    handleToggleBookmark,
+  };
+}

--- a/src/features/post/hooks/use-post-detail-comments.hook.ts
+++ b/src/features/post/hooks/use-post-detail-comments.hook.ts
@@ -1,0 +1,136 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import {
+  useCommentsInfiniteQuery,
+  useCreateCommentMutation,
+  useDeleteCommentMutation,
+  useToggleCommentHelpfulMutation,
+  useUpdateCommentMutation,
+} from "@/features/post/api";
+import type { PostCommentSortValue } from "@/features/post/ui";
+import type { CommentItemResponse } from "@/shared/api/generated";
+
+const COMMENT_SORT_QUERY_BY_VALUE: Record<PostCommentSortValue, "LATEST" | "HELPFUL"> = {
+  latest: "LATEST",
+  helpful: "HELPFUL",
+};
+
+type UsePostDetailCommentsParams = {
+  postId: number;
+  onAuthRequired: (error: unknown) => boolean;
+};
+
+/**
+ * 게시글 상세 댓글 목록과 댓글 mutation 핸들러를 관리하는 훅
+ *
+ * @description
+ * 댓글 정렬, cursor 기반 무한스크롤 조회, 작성/답글/수정/삭제, 유익해요 토글 흐름을 모읍니다.
+ * 댓글 CRUD는 mutation 성공 후 쿼리 무효화로 서버 상태를 다시 받아오고, 유익해요는 카드 내부 상태와 서버 응답을 동기화합니다.
+ *
+ * @param params.postId - 댓글을 조회하고 변경할 게시글 ID입니다.
+ * @param params.onAuthRequired - 인증 필요 에러 처리 핸들러입니다.
+ *
+ * @returns commentsResponse - 로드된 페이지를 합친 댓글 응답입니다.
+ * @returns commentSortValue - 현재 댓글 정렬 값입니다.
+ * @returns setCommentSortValue - 댓글 정렬 변경 함수입니다.
+ * @returns commentsQuery - 댓글 무한스크롤 쿼리 객체입니다.
+ * @returns isCreatingComment - 댓글 작성 요청 진행 여부입니다.
+ * @returns handleCreateComment - 원댓글 작성 핸들러입니다.
+ * @returns handleCreateReply - 답글 작성 핸들러입니다.
+ * @returns handleUpdateComment - 댓글 수정 핸들러입니다.
+ * @returns handleDeleteComment - 댓글 삭제 핸들러입니다.
+ * @returns handleToggleCommentHelpful - 유익해요 토글 핸들러입니다.
+ * @returns handleLoadMoreComments - 다음 댓글 페이지 로드 핸들러입니다.
+ */
+export function usePostDetailComments(params: UsePostDetailCommentsParams) {
+  const { postId, onAuthRequired } = params;
+  const [commentSortValue, setCommentSortValue] = useState<PostCommentSortValue>("latest");
+  const commentsQuery = useCommentsInfiniteQuery(postId, {
+    sortBy: COMMENT_SORT_QUERY_BY_VALUE[commentSortValue],
+    pageSize: 15,
+  });
+  const createCommentMutation = useCreateCommentMutation(postId);
+  const updateCommentMutation = useUpdateCommentMutation(postId);
+  const deleteCommentMutation = useDeleteCommentMutation(postId);
+  const toggleCommentHelpfulMutation = useToggleCommentHelpfulMutation(postId);
+
+  const commentsResponse = useMemo(() => {
+    const pages = commentsQuery.data?.pages ?? [];
+    const lastPage = pages.at(-1);
+
+    return {
+      comments: pages.flatMap((page) => page.comments),
+      hasNext: Boolean(commentsQuery.hasNextPage),
+      nextCursor: lastPage?.nextCursor ?? null,
+    };
+  }, [commentsQuery.data?.pages, commentsQuery.hasNextPage]);
+
+  const handleCreateComment = async (content: string) => {
+    try {
+      await createCommentMutation.mutateAsync({ parentId: null, content });
+    } catch (error) {
+      if (!onAuthRequired(error)) {
+        throw error;
+      }
+    }
+  };
+
+  const handleCreateReply = async (parentId: number, content: string) => {
+    try {
+      await createCommentMutation.mutateAsync({ parentId, content });
+    } catch (error) {
+      if (!onAuthRequired(error)) {
+        throw error;
+      }
+    }
+  };
+
+  const handleUpdateComment = async (commentId: number, content: string) => {
+    try {
+      await updateCommentMutation.mutateAsync({ commentId, content });
+    } catch (error) {
+      if (!onAuthRequired(error)) {
+        throw error;
+      }
+    }
+  };
+
+  const handleDeleteComment = async (commentId: number) => {
+    try {
+      await deleteCommentMutation.mutateAsync(commentId);
+    } catch (error) {
+      if (!onAuthRequired(error)) {
+        throw error;
+      }
+    }
+  };
+
+  const handleToggleCommentHelpful = async (comment: CommentItemResponse) => {
+    try {
+      return await toggleCommentHelpfulMutation.mutateAsync(comment);
+    } catch (error) {
+      onAuthRequired(error);
+      return {
+        isHelpful: comment.isHelpful,
+        totalHelpfulCount: comment.totalHelpfulCount,
+      };
+    }
+  };
+
+  const handleLoadMoreComments = useCallback(() => commentsQuery.fetchNextPage(), [commentsQuery.fetchNextPage]);
+
+  return {
+    commentsResponse,
+    commentSortValue,
+    setCommentSortValue,
+    commentsQuery,
+    isCreatingComment: createCommentMutation.isPending,
+    handleCreateComment,
+    handleCreateReply,
+    handleUpdateComment,
+    handleDeleteComment,
+    handleToggleCommentHelpful,
+    handleLoadMoreComments,
+  };
+}

--- a/src/features/post/hooks/use-post-detail-comments.hook.ts
+++ b/src/features/post/hooks/use-post-detail-comments.hook.ts
@@ -110,7 +110,10 @@ export function usePostDetailComments(params: UsePostDetailCommentsParams) {
     try {
       return await toggleCommentHelpfulMutation.mutateAsync(comment);
     } catch (error) {
-      onAuthRequired(error);
+      if (!onAuthRequired(error)) {
+        throw error;
+      }
+
       return {
         isHelpful: comment.isHelpful,
         totalHelpfulCount: comment.totalHelpfulCount,

--- a/src/features/post/ui/post-comment-card.tsx
+++ b/src/features/post/ui/post-comment-card.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import DotsThreeIcon from "@/assets/icons/dots-three.svg";
+import ThumbsUpIcon from "@/assets/icons/thumbs-up.svg";
+import { useCommentHelpfulState } from "@/features/post/hooks";
+import { PostDeleteModal, type PostDeleteMode } from "@/features/post/ui/contents-delete-modal";
+import { PostCommentForm } from "@/features/post/ui/post-comment-form";
+import type { CommentItemResponse } from "@/shared/api/generated";
+import { Tag } from "@/shared/ui";
+import { cn } from "@/shared/utils";
+import { formatRelativeTime } from "@/shared/utils/format";
+import type { PostCommentsSectionProps } from "./post-comments-section";
+
+type InteractiveHelpfulChipProps = {
+  count: number;
+  active?: boolean;
+  disabled?: boolean;
+  onToggle: () => void;
+};
+
+function InteractiveHelpfulChip(props: InteractiveHelpfulChipProps) {
+  const { count, active = false, disabled = false, onToggle } = props;
+
+  return (
+    <Tag
+      as="button"
+      tone={active ? "active" : "default"}
+      size="sm"
+      type="button"
+      disabled={disabled}
+      onClick={onToggle}
+      aria-pressed={active}
+      className="gap-1 disabled:opacity-60"
+    >
+      <ThumbsUpIcon aria-hidden className="size-4" strokeWidth={20} />
+      유익해요 {count}
+    </Tag>
+  );
+}
+
+type CommentActionMenuProps = {
+  idPrefix: string;
+  isOpen: boolean;
+  onToggle: () => void;
+  onClose: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+};
+
+function CommentActionMenu(props: CommentActionMenuProps) {
+  const { idPrefix, isOpen, onToggle, onClose, onEdit, onDelete } = props;
+  const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const firstActionRef = useRef<HTMLButtonElement>(null);
+  const menuId = `${idPrefix}-menu`;
+
+  useEffect(() => {
+    if (isOpen) {
+      firstActionRef.current?.focus();
+      return;
+    }
+
+    triggerRef.current?.focus();
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label="댓글 더보기"
+        aria-expanded={isOpen}
+        aria-haspopup="menu"
+        aria-controls={menuId}
+        onClick={onToggle}
+        className="focus:outline-none focus-visible:outline-none focus-visible:ring-0"
+      >
+        <DotsThreeIcon aria-hidden className="size-6 text-text-03" />
+      </button>
+      {isOpen ? (
+        <div
+          id={menuId}
+          role="menu"
+          className="absolute right-0 top-8 z-20 min-w-[110px] rounded-[16px] bg-bg-01 px-4 py-3 shadow-[0_8px_20px_rgba(0,0,0,0.12)]"
+        >
+          <button
+            ref={firstActionRef}
+            type="button"
+            role="menuitem"
+            className="block w-full py-1 text-left text-body-m text-text-03 focus:outline-none focus-visible:outline-none focus-visible:ring-0"
+            onClick={onEdit}
+          >
+            수정하기
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            className="mt-1 block w-full py-1 text-left text-body-m text-danger focus:outline-none focus-visible:outline-none focus-visible:ring-0"
+            onClick={onDelete}
+          >
+            삭제하기
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export type PostCommentCardProps = {
+  comment: CommentItemResponse;
+  replies: CommentItemResponse[];
+  onCreateReply: PostCommentsSectionProps["onCreateReply"];
+  onUpdateComment: PostCommentsSectionProps["onUpdateComment"];
+  onDeleteComment: PostCommentsSectionProps["onDeleteComment"];
+  onToggleHelpful: PostCommentsSectionProps["onToggleHelpful"];
+};
+
+export function PostCommentCard(props: PostCommentCardProps) {
+  const { comment, replies, onCreateReply, onUpdateComment, onDeleteComment, onToggleHelpful } = props;
+  const [isReplyOpen, setIsReplyOpen] = useState(false);
+  const [openActionMenuKey, setOpenActionMenuKey] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<{ mode: PostDeleteMode; commentId: number } | null>(null);
+  const [editingCommentId, setEditingCommentId] = useState<number | null>(null);
+  const {
+    commentHelpful,
+    isCommentHelpfulPending,
+    pendingReplyHelpfulId,
+    replyHelpfulMap,
+    toggleCommentHelpful,
+    toggleReplyHelpful,
+  } = useCommentHelpfulState({
+    comment,
+    replies,
+    onToggleHelpful,
+  });
+
+  const toggleActionMenu = (key: string) => {
+    setOpenActionMenuKey((prev) => (prev === key ? null : key));
+  };
+
+  const startEdit = (target: CommentItemResponse) => {
+    setOpenActionMenuKey(null);
+    setEditingCommentId(target.commentId);
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteTarget) {
+      return;
+    }
+
+    await onDeleteComment(deleteTarget.commentId);
+    setDeleteTarget(null);
+  };
+
+  const renderCommentBody = (target: CommentItemResponse, isReply = false) => {
+    const isEditing = editingCommentId === target.commentId;
+    if (isEditing) {
+      return (
+        <div className={isReply ? "mt-2" : "mt-[11px]"}>
+          <PostCommentForm
+            initialContent={target.content}
+            ariaLabel={isReply ? "답글 수정 입력" : "댓글 수정 입력"}
+            showActions
+            onCancel={() => setEditingCommentId(null)}
+            onSubmit={async (content) => {
+              await onUpdateComment(target.commentId, content);
+              setEditingCommentId(null);
+            }}
+          />
+        </div>
+      );
+    }
+
+    return (
+      <p className={cn("whitespace-pre-line text-caption-m text-text-03", isReply ? "mt-2" : "mt-[11px]")}>
+        {target.isDeleted ? "삭제된 의견입니다." : target.content}
+      </p>
+    );
+  };
+
+  return (
+    <article className="rounded-[12px] bg-bg-02 p-5">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <strong className="text-body-m text-text-04">
+            {comment.writer.nickname}
+            {comment.writer.isPostWriter ? <span className="ml-0.5 text-small-m">(작성자)</span> : null}
+          </strong>
+          <span className="text-[10px] leading-[1.5] text-text-03">{formatRelativeTime(comment.createdAt)}</span>
+        </div>
+        {comment.isMine && !comment.isDeleted ? (
+          <CommentActionMenu
+            idPrefix={`comment-${comment.commentId}`}
+            isOpen={openActionMenuKey === `comment-${comment.commentId}`}
+            onToggle={() => toggleActionMenu(`comment-${comment.commentId}`)}
+            onClose={() => setOpenActionMenuKey(null)}
+            onEdit={() => startEdit(comment)}
+            onDelete={() => {
+              setOpenActionMenuKey(null);
+              setDeleteTarget({ mode: "opinion", commentId: comment.commentId });
+            }}
+          />
+        ) : null}
+      </div>
+      {renderCommentBody(comment)}
+
+      {!comment.isDeleted ? (
+        <div className="mt-3 flex items-center gap-2">
+          <InteractiveHelpfulChip
+            count={commentHelpful.count}
+            active={commentHelpful.active}
+            disabled={isCommentHelpfulPending}
+            onToggle={toggleCommentHelpful}
+          />
+          <button type="button" className="text-small-m text-text-03" onClick={() => setIsReplyOpen((prev) => !prev)}>
+            {isReplyOpen ? "답글 닫기" : "답글 달기"}
+          </button>
+        </div>
+      ) : null}
+
+      {isReplyOpen ? (
+        <div className="mt-3">
+          <PostCommentForm
+            isReply
+            ariaLabel="답글 입력"
+            onSubmit={async (content) => {
+              await onCreateReply(comment.commentId, content);
+              setIsReplyOpen(false);
+            }}
+          />
+        </div>
+      ) : null}
+
+      {replies.map((reply) => {
+        const replyHelpful = replyHelpfulMap[reply.commentId] ?? {
+          active: reply.isHelpful,
+          count: reply.totalHelpfulCount,
+        };
+
+        return (
+          <div key={reply.commentId} className="mt-4 pl-5">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <strong className="text-body-m text-text-04">
+                  {reply.writer.nickname}
+                  {reply.writer.isPostWriter ? <span className="ml-0.5 text-small-m">(작성자)</span> : null}
+                </strong>
+                <span className="text-[10px] leading-[1.5] text-text-03">{formatRelativeTime(reply.createdAt)}</span>
+              </div>
+              {reply.isMine && !reply.isDeleted ? (
+                <CommentActionMenu
+                  idPrefix={`reply-${reply.commentId}`}
+                  isOpen={openActionMenuKey === `reply-${reply.commentId}`}
+                  onToggle={() => toggleActionMenu(`reply-${reply.commentId}`)}
+                  onClose={() => setOpenActionMenuKey(null)}
+                  onEdit={() => startEdit(reply)}
+                  onDelete={() => {
+                    setOpenActionMenuKey(null);
+                    setDeleteTarget({ mode: "reply", commentId: reply.commentId });
+                  }}
+                />
+              ) : null}
+            </div>
+            {renderCommentBody(reply, true)}
+            {!reply.isDeleted ? (
+              <div className="mt-2">
+                <InteractiveHelpfulChip
+                  count={replyHelpful.count}
+                  active={replyHelpful.active}
+                  disabled={pendingReplyHelpfulId === reply.commentId}
+                  onToggle={() => toggleReplyHelpful(reply)}
+                />
+              </div>
+            ) : null}
+          </div>
+        );
+      })}
+      <PostDeleteModal
+        open={deleteTarget !== null}
+        mode={deleteTarget?.mode ?? "opinion"}
+        onClose={() => setDeleteTarget(null)}
+        onConfirmDelete={confirmDelete}
+      />
+    </article>
+  );
+}

--- a/src/features/post/ui/post-comment-card.tsx
+++ b/src/features/post/ui/post-comment-card.tsx
@@ -230,7 +230,7 @@ export function PostCommentCard(props: PostCommentCardProps) {
       </div>
       {renderCommentBody(comment)}
 
-      {!comment.isDeleted ? (
+      {!comment.isDeleted && !comment.isMine ? (
         <div className="mt-3 flex items-center gap-2">
           <InteractiveHelpfulChip
             count={commentHelpful.count}
@@ -288,7 +288,7 @@ export function PostCommentCard(props: PostCommentCardProps) {
               ) : null}
             </div>
             {renderCommentBody(reply, true)}
-            {!reply.isDeleted ? (
+            {!reply.isDeleted && !reply.isMine ? (
               <div className="mt-2">
                 <InteractiveHelpfulChip
                   count={replyHelpful.count}

--- a/src/features/post/ui/post-comment-card.tsx
+++ b/src/features/post/ui/post-comment-card.tsx
@@ -230,14 +230,16 @@ export function PostCommentCard(props: PostCommentCardProps) {
       </div>
       {renderCommentBody(comment)}
 
-      {!comment.isDeleted && !comment.isMine ? (
+      {!comment.isDeleted ? (
         <div className="mt-3 flex items-center gap-2">
-          <InteractiveHelpfulChip
-            count={commentHelpful.count}
-            active={commentHelpful.active}
-            disabled={isCommentHelpfulPending}
-            onToggle={toggleCommentHelpful}
-          />
+          {!comment.isMine ? (
+            <InteractiveHelpfulChip
+              count={commentHelpful.count}
+              active={commentHelpful.active}
+              disabled={isCommentHelpfulPending}
+              onToggle={toggleCommentHelpful}
+            />
+          ) : null}
           <button type="button" className="text-small-m text-text-03" onClick={() => setIsReplyOpen((prev) => !prev)}>
             {isReplyOpen ? "답글 닫기" : "답글 달기"}
           </button>

--- a/src/features/post/ui/post-comment-form.tsx
+++ b/src/features/post/ui/post-comment-form.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { Button, CommentTextfield } from "@/shared/ui";
+
+export const COMMENT_CONTENT_MAX_LENGTH = 300;
+
+type CommentFormData = {
+  content: string;
+};
+
+export type PostCommentFormProps = {
+  ariaLabel?: string;
+  initialContent?: string;
+  isReply?: boolean;
+  isSubmitting?: boolean;
+  submitLabel?: string;
+  showActions?: boolean;
+  onCancel?: () => void;
+  onSubmit: (content: string) => Promise<void>;
+};
+
+function isValidCommentContent(content: string) {
+  return content.trim().length > 0 && content.trim().length <= COMMENT_CONTENT_MAX_LENGTH;
+}
+
+// 댓글 작성, 답글 작성, 댓글 수정을 같은 폼 흐름으로 묶어 입력/검증/submit 상태를 한 곳에서 관리한다.
+export function PostCommentForm(props: PostCommentFormProps) {
+  const {
+    ariaLabel,
+    initialContent = "",
+    isReply = false,
+    isSubmitting = false,
+    submitLabel = "저장",
+    showActions = false,
+    onCancel,
+    onSubmit,
+  } = props;
+  const {
+    formState: { isSubmitting: isFormSubmitting },
+    handleSubmit,
+    register,
+    reset,
+    watch,
+  } = useForm<CommentFormData>({
+    defaultValues: {
+      content: initialContent,
+    },
+  });
+  const content = watch("content");
+  const trimmedContent = content.trim();
+  const isPending = isSubmitting || isFormSubmitting;
+  const isUnchanged = initialContent.trim().length > 0 && trimmedContent === initialContent.trim();
+  const isSubmitDisabled = !isValidCommentContent(content) || isUnchanged || isPending;
+  const contentField = register("content");
+
+  useEffect(() => {
+    reset({ content: initialContent });
+  }, [initialContent, reset]);
+
+  const submit = handleSubmit(async (values) => {
+    if (isSubmitDisabled) {
+      return;
+    }
+
+    await onSubmit(values.content.trim());
+    reset({ content: "" });
+  });
+
+  return (
+    <div className="flex flex-col gap-2">
+      <CommentTextfield
+        name={contentField.name}
+        value={content}
+        onBlur={contentField.onBlur}
+        onChange={contentField.onChange}
+        onSubmit={submit}
+        isReply={isReply}
+        ariaLabel={ariaLabel}
+        submitDisabled={isSubmitDisabled}
+        isSubmitting={isPending}
+      />
+      {showActions ? (
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="inactive" size="chip" onClick={onCancel}>
+            취소
+          </Button>
+          <Button type="button" variant="primary" size="chip" disabled={isSubmitDisabled} onClick={submit}>
+            {submitLabel}
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/features/post/ui/post-comments-section.tsx
+++ b/src/features/post/ui/post-comments-section.tsx
@@ -6,7 +6,8 @@ import ChatIcon from "@/assets/icons/chat.svg";
 import { PostCommentCard } from "@/features/post/ui/post-comment-card";
 import { PostCommentForm } from "@/features/post/ui/post-comment-form";
 import type { CommentItemResponse, CommentReadResponse } from "@/shared/api/generated";
-import { useInfiniteScrollObserver } from "@/shared/hooks";
+// TODO: 공용 useInfiniteScrollObserver가 홈 피드 PR에 포함되면 주석을 해제해 댓글 무한스크롤도 다시 연결한다.
+// import { useInfiniteScrollObserver } from "@/shared/hooks";
 import { SortSelect, type SortSelectOption } from "@/shared/ui";
 import { cn } from "@/shared/utils";
 
@@ -59,11 +60,11 @@ export function PostCommentsSection(props: PostCommentsSectionProps) {
     ...rest
   } = props;
   const comments = commentsResponse.comments;
-  const loadMoreRef = useInfiniteScrollObserver({
-    enabled: hasNextPage,
-    isFetching: isFetchingNextPage,
-    onIntersect: onLoadMore,
-  });
+  // const loadMoreRef = useInfiniteScrollObserver({
+  //   enabled: hasNextPage,
+  //   isFetching: isFetchingNextPage,
+  //   onIntersect: onLoadMore,
+  // });
   const rootComments = useMemo(() => {
     const roots = comments.filter((comment) => comment.parentId === null);
     const sorted = [...roots];
@@ -133,9 +134,9 @@ export function PostCommentsSection(props: PostCommentsSectionProps) {
       ) : (
         <EmptyComments />
       )}
-      <div ref={loadMoreRef} className="flex min-h-8 items-center justify-center py-2">
+      {/* <div ref={loadMoreRef} className="flex min-h-8 items-center justify-center py-2">
         {isFetchingNextPage ? <span className="text-caption-m text-text-03">댓글을 더 불러오는 중...</span> : null}
-      </div>
+      </div> */}
     </section>
   );
 }

--- a/src/features/post/ui/post-comments-section.tsx
+++ b/src/features/post/ui/post-comments-section.tsx
@@ -1,300 +1,36 @@
 "use client";
 
 import type { ComponentProps } from "react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo } from "react";
 import ChatIcon from "@/assets/icons/chat.svg";
-import DotsThreeIcon from "@/assets/icons/dots-three.svg";
-import ThumbsUpIcon from "@/assets/icons/thumbs-up.svg";
-import { PostDeleteModal, type PostDeleteMode } from "@/features/post/ui/contents-delete-modal";
-import { CommentTextfield, SortSelect, type SortSelectOption, Tag } from "@/shared/ui";
+import { PostCommentCard } from "@/features/post/ui/post-comment-card";
+import { PostCommentForm } from "@/features/post/ui/post-comment-form";
+import type { CommentItemResponse, CommentReadResponse } from "@/shared/api/generated";
+import { useInfiniteScrollObserver } from "@/shared/hooks";
+import { SortSelect, type SortSelectOption } from "@/shared/ui";
 import { cn } from "@/shared/utils";
-import { formatRelativeTime } from "@/shared/utils/format";
 
-export type PostCommentReply = {
-  commentId: number;
-  isMine: boolean;
-  createdAt: string;
-  updatedAt: string;
-  content: string;
-  isDeleted: boolean;
-  isHelpful: boolean;
-  totalHelpfulCount: number;
-  parentId: number | null;
-  depth: number;
-  writer: {
-    nickname: string;
-    profileImageUrl?: string | null;
-    isPostWriter: boolean;
-  };
-};
-
-export type PostCommentItem = {
-  commentId: number;
-  isMine: boolean;
-  createdAt: string;
-  updatedAt: string;
-  content: string;
-  isDeleted: boolean;
-  isHelpful: boolean;
-  totalHelpfulCount: number;
-  parentId: number | null;
-  depth: number;
-  writer: {
-    nickname: string;
-    profileImageUrl?: string | null;
-    isPostWriter: boolean;
-  };
-};
+export type PostCommentSortValue = "latest" | "helpful";
 
 export type PostCommentsSectionProps = ComponentProps<"section"> & {
-  commentsResponse: {
-    comments: PostCommentItem[];
-    hasNext: boolean;
-    nextCursor: string | null;
-  };
-  sortLabel?: string;
+  commentsResponse: CommentReadResponse;
+  sortValue: PostCommentSortValue;
+  onSortChange: (value: PostCommentSortValue) => void;
+  onCreateComment: (content: string) => Promise<void>;
+  onCreateReply: (parentId: number, content: string) => Promise<void>;
+  onUpdateComment: (commentId: number, content: string) => Promise<void>;
+  onDeleteComment: (commentId: number) => Promise<void>;
+  onToggleHelpful: (comment: CommentItemResponse) => Promise<{ isHelpful: boolean; totalHelpfulCount: number }>;
+  isCreatingComment?: boolean;
+  hasNextPage?: boolean;
+  isFetchingNextPage?: boolean;
+  onLoadMore?: () => Promise<unknown>;
 };
 
 const COMMENT_SORT_OPTIONS = [
   { value: "latest", label: "최신순" },
   { value: "helpful", label: "유익해요순" },
-] satisfies readonly SortSelectOption<"latest" | "helpful">[];
-
-type InteractiveHelpfulChipProps = {
-  count: number;
-  active?: boolean;
-  onToggle: () => void;
-};
-
-function InteractiveHelpfulChip(props: InteractiveHelpfulChipProps) {
-  const { count, active = false, onToggle } = props;
-
-  return (
-    <Tag
-      as="button"
-      tone={active ? "active" : "default"}
-      size="sm"
-      type="button"
-      onClick={onToggle}
-      aria-pressed={active}
-      className="gap-1"
-    >
-      <ThumbsUpIcon aria-hidden className="size-4" strokeWidth={20} />
-      유익해요 {count}
-    </Tag>
-  );
-}
-
-type CommentActionMenuProps = {
-  idPrefix: string;
-  isOpen: boolean;
-  onToggle: () => void;
-  onClose: () => void;
-  onDelete: () => void;
-};
-
-function CommentActionMenu(props: CommentActionMenuProps) {
-  const { idPrefix, isOpen, onToggle, onClose, onDelete } = props;
-  const containerRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const firstActionRef = useRef<HTMLButtonElement>(null);
-  const menuId = `${idPrefix}-menu`;
-
-  useEffect(() => {
-    if (isOpen) {
-      firstActionRef.current?.focus();
-      return;
-    }
-
-    triggerRef.current?.focus();
-  }, [isOpen]);
-
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    const handlePointerDown = (event: PointerEvent) => {
-      if (!containerRef.current?.contains(event.target as Node)) {
-        onClose();
-      }
-    };
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        onClose();
-      }
-    };
-
-    document.addEventListener("pointerdown", handlePointerDown);
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("pointerdown", handlePointerDown);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [isOpen, onClose]);
-
-  return (
-    <div ref={containerRef} className="relative">
-      <button
-        ref={triggerRef}
-        type="button"
-        aria-label="댓글 더보기"
-        aria-expanded={isOpen}
-        aria-haspopup="menu"
-        aria-controls={menuId}
-        onClick={onToggle}
-        className="focus:outline-none focus-visible:outline-none focus-visible:ring-0"
-      >
-        <DotsThreeIcon aria-hidden className="size-6 text-text-03" />
-      </button>
-      {isOpen ? (
-        <div
-          id={menuId}
-          role="menu"
-          className="absolute right-0 top-8 z-20 min-w-[110px] rounded-[16px] bg-bg-01 px-4 py-3 shadow-[0_8px_20px_rgba(0,0,0,0.12)]"
-        >
-          <button
-            ref={firstActionRef}
-            type="button"
-            role="menuitem"
-            className="block w-full py-1 text-left text-body-m text-text-03 focus:outline-none focus-visible:outline-none focus-visible:ring-0"
-          >
-            수정하기
-          </button>
-          <button
-            type="button"
-            role="menuitem"
-            className="mt-1 block w-full py-1 text-left text-body-m text-danger focus:outline-none focus-visible:outline-none focus-visible:ring-0"
-            onClick={onDelete}
-          >
-            삭제하기
-          </button>
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function CommentCard({ comment, replies }: { comment: PostCommentItem; replies: PostCommentReply[] }) {
-  const [isHelpful, setIsHelpful] = useState(Boolean(comment.isHelpful));
-  const [helpfulCount, setHelpfulCount] = useState(comment.totalHelpfulCount);
-  const [isReplyOpen, setIsReplyOpen] = useState(false);
-  const [replyText, setReplyText] = useState("");
-  const [openActionMenuKey, setOpenActionMenuKey] = useState<string | null>(null);
-  const [deleteMode, setDeleteMode] = useState<PostDeleteMode | null>(null);
-  const [replyHelpfulMap, setReplyHelpfulMap] = useState<Record<number, { active: boolean; count: number }>>(() =>
-    Object.fromEntries(
-      replies.map((reply) => [reply.commentId, { active: reply.isHelpful, count: reply.totalHelpfulCount }]),
-    ),
-  );
-
-  const toggleHelpful = () => {
-    const nextActive = !isHelpful;
-    setIsHelpful(nextActive);
-    setHelpfulCount((count) => (nextActive ? count + 1 : Math.max(0, count - 1)));
-  };
-
-  const toggleReplyHelpful = (replyId: number) => {
-    setReplyHelpfulMap((prev) => {
-      const current = prev[replyId] ?? { active: false, count: 0 };
-      const nextActive = !current.active;
-      const nextCount = nextActive ? current.count + 1 : Math.max(0, current.count - 1);
-      return { ...prev, [replyId]: { active: nextActive, count: nextCount } };
-    });
-  };
-
-  const toggleActionMenu = (key: string) => {
-    setOpenActionMenuKey((prev) => (prev === key ? null : key));
-  };
-
-  return (
-    <article className="rounded-[12px] bg-bg-02 p-5">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <strong className="text-body-m text-text-04">
-            {comment.writer.nickname}
-            {comment.writer.isPostWriter ? <span className="ml-0.5 text-small-m">(작성자)</span> : null}
-          </strong>
-          <span className="text-[10px] leading-[1.5] text-text-03">{formatRelativeTime(comment.createdAt)}</span>
-        </div>
-        {comment.isMine ? (
-          <CommentActionMenu
-            idPrefix={`comment-${comment.commentId}`}
-            isOpen={openActionMenuKey === `comment-${comment.commentId}`}
-            onToggle={() => toggleActionMenu(`comment-${comment.commentId}`)}
-            onClose={() => setOpenActionMenuKey(null)}
-            onDelete={() => {
-              setOpenActionMenuKey(null);
-              setDeleteMode("opinion");
-            }}
-          />
-        ) : null}
-      </div>
-      <p className="mt-[11px] whitespace-pre-line text-caption-m text-text-03">
-        {comment.isDeleted ? "삭제된 의견입니다." : comment.content}
-      </p>
-
-      <div className="mt-3 flex items-center gap-2">
-        <InteractiveHelpfulChip count={helpfulCount} active={isHelpful} onToggle={toggleHelpful} />
-        <button type="button" className="text-small-m text-text-03" onClick={() => setIsReplyOpen((prev) => !prev)}>
-          {isReplyOpen ? "답글 닫기" : "답글 달기"}
-        </button>
-      </div>
-
-      {isReplyOpen ? (
-        <div className="mt-3">
-          <CommentTextfield
-            isReply
-            value={replyText}
-            onChange={(event) => setReplyText(event.target.value)}
-            ariaLabel="답글 입력"
-          />
-        </div>
-      ) : null}
-
-      {replies.map((reply) => (
-        <div key={reply.commentId} className="mt-4 pl-5">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <strong className="text-body-m text-text-04">
-                {reply.writer.nickname}
-                {reply.writer.isPostWriter ? <span className="ml-0.5 text-small-m">(작성자)</span> : null}
-              </strong>
-              <span className="text-[10px] leading-[1.5] text-text-03">{formatRelativeTime(reply.createdAt)}</span>
-            </div>
-            {reply.isMine ? (
-              <CommentActionMenu
-                idPrefix={`reply-${reply.commentId}`}
-                isOpen={openActionMenuKey === `reply-${reply.commentId}`}
-                onToggle={() => toggleActionMenu(`reply-${reply.commentId}`)}
-                onClose={() => setOpenActionMenuKey(null)}
-                onDelete={() => {
-                  setOpenActionMenuKey(null);
-                  setDeleteMode("reply");
-                }}
-              />
-            ) : null}
-          </div>
-          <p className="mt-2 text-caption-m text-text-03">{reply.isDeleted ? "삭제된 의견입니다." : reply.content}</p>
-          <div className="mt-2">
-            <InteractiveHelpfulChip
-              count={replyHelpfulMap[reply.commentId]?.count ?? reply.totalHelpfulCount}
-              active={replyHelpfulMap[reply.commentId]?.active}
-              onToggle={() => toggleReplyHelpful(reply.commentId)}
-            />
-          </div>
-        </div>
-      ))}
-      <PostDeleteModal
-        open={deleteMode !== null}
-        mode={deleteMode ?? "opinion"}
-        onClose={() => setDeleteMode(null)}
-        onConfirmDelete={() => setDeleteMode(null)}
-      />
-    </article>
-  );
-}
+] satisfies readonly SortSelectOption<PostCommentSortValue>[];
 
 function EmptyComments() {
   return (
@@ -306,27 +42,44 @@ function EmptyComments() {
 }
 
 export function PostCommentsSection(props: PostCommentsSectionProps) {
-  const { commentsResponse, sortLabel = "최신순", className, ...rest } = props;
-  const initialSortValue = sortLabel === "유익해요순" ? "helpful" : "latest";
-  const [sortValue, setSortValue] = useState<"latest" | "helpful">(initialSortValue);
+  const {
+    commentsResponse,
+    sortValue,
+    onSortChange,
+    onCreateComment,
+    onCreateReply,
+    onUpdateComment,
+    onDeleteComment,
+    onToggleHelpful,
+    isCreatingComment = false,
+    hasNextPage = false,
+    isFetchingNextPage = false,
+    onLoadMore,
+    className,
+    ...rest
+  } = props;
   const comments = commentsResponse.comments;
+  const loadMoreRef = useInfiniteScrollObserver({
+    enabled: hasNextPage,
+    isFetching: isFetchingNextPage,
+    onIntersect: onLoadMore,
+  });
   const rootComments = useMemo(() => {
-    const roots = comments.filter((comment) => comment.depth === 1);
+    const roots = comments.filter((comment) => comment.parentId === null);
     const sorted = [...roots];
     sorted.sort((a, b) => {
-      if (sortValue === "helpful") {
-        if (b.totalHelpfulCount !== a.totalHelpfulCount) {
-          return b.totalHelpfulCount - a.totalHelpfulCount;
-        }
+      if (sortValue === "helpful" && b.totalHelpfulCount !== a.totalHelpfulCount) {
+        return b.totalHelpfulCount - a.totalHelpfulCount;
       }
+
       return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
     });
     return sorted;
   }, [comments, sortValue]);
   const replyMap = useMemo(() => {
-    const byParent: Record<number, PostCommentReply[]> = {};
+    const byParent: Record<number, CommentItemResponse[]> = {};
     comments
-      .filter((comment): comment is PostCommentReply => comment.depth > 1)
+      .filter((comment) => comment.parentId !== null)
       .forEach((reply) => {
         const parentId = reply.parentId;
         if (parentId === null) {
@@ -349,29 +102,40 @@ export function PostCommentsSection(props: PostCommentsSectionProps) {
   return (
     <section className={cn("flex flex-col gap-4", className)} aria-label="집단 지성 댓글" {...rest}>
       <div className="flex flex-col gap-1">
-        <h2 className="text-subtitle-b text-text-04">집단 지성 ({rootComments.length})</h2>
+        <h2 className="text-subtitle-b text-text-04">로드된 집단 지성 ({rootComments.length})</h2>
         <div className="flex justify-end">
           <SortSelect
             value={sortValue}
             options={COMMENT_SORT_OPTIONS}
-            onChange={setSortValue}
+            onChange={onSortChange}
             ariaLabel="집단 지성 정렬"
             className="text-caption-m text-text-03"
           />
         </div>
       </div>
 
-      <CommentTextfield />
+      <PostCommentForm onSubmit={onCreateComment} isSubmitting={isCreatingComment} />
 
       {rootComments.length > 0 ? (
         <div className="flex flex-col gap-3">
           {rootComments.map((comment) => (
-            <CommentCard key={comment.commentId} comment={comment} replies={replyMap[comment.commentId] ?? []} />
+            <PostCommentCard
+              key={comment.commentId}
+              comment={comment}
+              replies={replyMap[comment.commentId] ?? []}
+              onCreateReply={onCreateReply}
+              onUpdateComment={onUpdateComment}
+              onDeleteComment={onDeleteComment}
+              onToggleHelpful={onToggleHelpful}
+            />
           ))}
         </div>
       ) : (
         <EmptyComments />
       )}
+      <div ref={loadMoreRef} className="flex min-h-8 items-center justify-center py-2">
+        {isFetchingNextPage ? <span className="text-caption-m text-text-03">댓글을 더 불러오는 중...</span> : null}
+      </div>
     </section>
   );
 }

--- a/src/features/post/ui/post-detail-card.tsx
+++ b/src/features/post/ui/post-detail-card.tsx
@@ -30,7 +30,11 @@ export type PostDetailHeaderProps = {
   meta: string;
   viewCount: number;
   isBookmarked?: boolean;
+  isBookmarking?: boolean;
   isMine?: boolean;
+  isDeleting?: boolean;
+  onBookmarkToggle?: () => void;
+  onDelete?: () => void;
   className?: string;
 };
 
@@ -40,7 +44,19 @@ function IconButton(props: ComponentProps<"button">) {
 }
 
 export function PostDetailHeader(props: PostDetailHeaderProps) {
-  const { postId, category, meta, viewCount, isBookmarked = false, isMine = false, className } = props;
+  const {
+    postId,
+    category,
+    meta,
+    viewCount,
+    isBookmarked = false,
+    isBookmarking = false,
+    isMine = false,
+    isDeleting = false,
+    onBookmarkToggle,
+    onDelete,
+    className,
+  } = props;
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -87,7 +103,12 @@ export function PostDetailHeader(props: PostDetailHeaderProps) {
           </li>
         </ul>
         <div className="inline-flex items-center gap-3 text-text-03">
-          <IconButton aria-label="북마크">
+          <IconButton
+            aria-label={isBookmarked ? "북마크 해제" : "북마크"}
+            aria-pressed={isBookmarked}
+            disabled={isBookmarking}
+            onClick={onBookmarkToggle}
+          >
             {isBookmarked ? (
               <BookmarkFillIcon aria-hidden className={cn(iconClassName, "text-text-03")} />
             ) : (
@@ -119,6 +140,7 @@ export function PostDetailHeader(props: PostDetailHeaderProps) {
                   <button
                     type="button"
                     className="mt-1 block w-full py-1 text-left text-body-m text-danger focus:outline-none focus-visible:outline-none focus-visible:ring-0"
+                    disabled={isDeleting}
                     onClick={() => {
                       setIsMenuOpen(false);
                       setIsDeleteModalOpen(true);
@@ -141,7 +163,11 @@ export function PostDetailHeader(props: PostDetailHeaderProps) {
         open={isDeleteModalOpen}
         mode="post"
         onClose={() => setIsDeleteModalOpen(false)}
-        onConfirmDelete={() => setIsDeleteModalOpen(false)}
+        confirmText={isDeleting ? "삭제 중" : "삭제하기"}
+        onConfirmDelete={() => {
+          onDelete?.();
+          setIsDeleteModalOpen(false);
+        }}
       />
     </>
   );

--- a/src/shared/ui/comment-textfield.tsx
+++ b/src/shared/ui/comment-textfield.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEventHandler } from "react";
+import type { ChangeEventHandler, ComponentProps, FocusEventHandler } from "react";
 import PaperPlaneRightIcon from "@/assets/icons/paper-plane-right.svg";
 import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
@@ -11,22 +11,43 @@ export type CommentTextfieldProps = {
   value?: string;
   defaultValue?: string;
   onChange?: ChangeEventHandler<HTMLInputElement>;
+  onBlur?: FocusEventHandler<HTMLInputElement>;
+  onSubmit?: ComponentProps<"form">["onSubmit"];
   isReply?: boolean;
   state?: CommentTextfieldState;
   name?: string;
   ariaLabel?: string;
   className?: string;
+  disabled?: boolean;
+  submitDisabled?: boolean;
+  isSubmitting?: boolean;
 };
 
 export function CommentTextfield(props: CommentTextfieldProps) {
-  const { id, value, defaultValue, onChange, isReply = false, state = "default", name, ariaLabel, className } = props;
+  const {
+    id,
+    value,
+    defaultValue,
+    onChange,
+    onBlur,
+    onSubmit,
+    isReply = false,
+    state = "default",
+    name,
+    ariaLabel,
+    className,
+    disabled = false,
+    submitDisabled = false,
+    isSubmitting = false,
+  } = props;
   const resolvedPlaceholder = isReply ? "내용을 입력해 주세요." : "당신의 의견을 남겨주세요...";
   const resolvedAriaLabel = ariaLabel ?? (isReply ? "답글 입력" : "댓글 입력");
-  const isDisabled = state === "disabled";
+  const isDisabled = disabled || isSubmitting || state === "disabled";
+  const isSubmitDisabled = isDisabled || submitDisabled;
   const isReadOnly = value !== undefined && onChange === undefined;
 
   return (
-    <div className={cn("flex w-full items-center gap-2 rounded-[12px]", className)}>
+    <form onSubmit={onSubmit} className={cn("flex w-full items-center gap-2 rounded-[12px]", className)}>
       <div
         className={cn(
           "flex h-[44px] flex-1 items-center rounded-common-radius px-3 py-2",
@@ -42,6 +63,7 @@ export function CommentTextfield(props: CommentTextfieldProps) {
           value={value}
           defaultValue={defaultValue}
           onChange={onChange}
+          onBlur={onBlur}
           readOnly={isReadOnly}
           disabled={isDisabled}
           placeholder={isDisabled ? "의견을 남길 수 없습니다." : resolvedPlaceholder}
@@ -50,22 +72,22 @@ export function CommentTextfield(props: CommentTextfieldProps) {
       </div>
 
       <Button
-        type="button"
+        type="submit"
         variant="primary"
         size="iconSm"
         className={cn(
           "size-10 [--button-radius:var(--radius-common-radius)]",
-          isDisabled ? "bg-bg-03" : "bg-primary-strong hover:bg-primary-strong",
+          isSubmitDisabled ? "bg-bg-03" : "bg-primary-strong hover:bg-primary-strong",
         )}
         aria-label="전송"
-        disabled={isDisabled}
+        disabled={isSubmitDisabled}
       >
         <PaperPlaneRightIcon
           aria-hidden
-          className={cn("size-6", isDisabled ? "text-text-02" : "text-text-01")}
+          className={cn("size-6", isSubmitDisabled ? "text-text-02" : "text-text-01")}
           strokeWidth={20}
         />
       </Button>
-    </div>
+    </form>
   );
 }


### PR DESCRIPTION
## 📋 변경 사항

게시글 상세페이지의 mock data를 제거하고 백엔드 API 기반으로 상세/댓글 흐름을 연결했습니다.

- 게시글 상세 조회 API 연동
- 게시글 삭제 API 연동 및 삭제 후 이동 처리
- 댓글 목록 무한스크롤 연동
- 댓글 작성 / 답글 작성 / 수정 / 삭제 API 연동
- 댓글 유익해요 토글 API 연동
- 게시글 북마크 토글 API 연동
- 로딩 / 에러 / not found / empty 상태 처리
- 댓글 폼과 댓글 카드 컴포넌트 분리
- 상세 화면 핸들러 로직을 hook으로 분리

게시글 작성/수정 페이지와 이미지 업로드 연동은 이번 PR 범위에서 제외했습니다.

## 🏷️ PR 유형

- [x] 🚀 feat: 새로운 기능 추가
- [ ] 🐛 fix: 버그 수정
- [x] ♻️ refactor: 코드 리팩토링
- [ ] 📝 docs: 문서 수정
- [ ] ✅ test: 테스트 코드 추가/수정
- [ ] 🔧 chore: 빌드/패키지 매니저 수정

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션 준수
- [x] 로컬 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📸 테스트 결과

현재 게시글 작성/수정 페이지가 아직 API와 연결되지 않아, 신규 게시글 생성 후 상세 진입까지의 전체 플로우 검증은 후속 PR에서 진행 예정입니다.

## 🔗 관련 이슈

- Closes #51