### PR TITLE
feat: 홈 피드 목데이터 제거 및 API 연동

### DIFF
--- a/src/app/_components/home.client.tsx
+++ b/src/app/_components/home.client.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useMemo, useState } from "react";
 import SectionPlusIcon from "@/assets/icons/selection-plus.svg";
-import { type GetHomePostsParams, useHomePostsInfiniteQuery } from "@/features/post/api";
+import { type GetHomePostsParams, useHomePostsInfiniteQuery, useTogglePostBookmarkMutation } from "@/features/post/api";
 import { POST_CATEGORY_VALUE_BY_LABEL, type PostCategoryLabel } from "@/features/post/constants";
 import { getPrimaryPostCategoryLabel } from "@/features/post/model";
 import { useInfiniteScrollObserver } from "@/shared/hooks";
@@ -18,8 +18,7 @@ import {
 } from "@/shared/ui";
 import { formatRelativeTime } from "@/shared/utils/format";
 import { FooterWidget } from "@/widgets/footer/ui";
-import type { SubHeadingWidgetProps } from "@/widgets/sub-heading/ui/sub-heading.widget";
-import { SubHeadingWidget } from "@/widgets/sub-heading/ui/sub-heading.widget";
+import { SubHeadingWidget, type SubHeadingWidgetProps } from "@/widgets/sub-heading/ui/sub-heading.widget";
 
 type HomeCategory = Extract<NonNullable<SubHeadingWidgetProps["selectedOptions"]>[number], PostCategoryLabel>;
 type HomeSortValue = NonNullable<SubHeadingWidgetProps["sortValue"]>;
@@ -37,6 +36,9 @@ const HOME_SORT_QUERY_BY_VALUE: Record<
 export default function HomePageClient() {
   const [selectedCategories, setSelectedCategories] = useState<HomeCategory[]>([]);
   const [sortValue, setSortValue] = useState<HomeSortValue>("latest");
+  const bookmarkMutation = useTogglePostBookmarkMutation();
+
+  // 화면 필터 값을 백엔드 홈 피드 query parameter로 변환한다.
   const selectedCategoryQuery = selectedCategories.map((category) => POST_CATEGORY_VALUE_BY_LABEL[category]).join(",");
 
   const homePostsQuery = useHomePostsInfiniteQuery({
@@ -44,9 +46,10 @@ export default function HomePageClient() {
     sortBy: HOME_SORT_QUERY_BY_VALUE[sortValue],
     pageSize: 10,
   });
+
+  // infinite query 응답을 화면에서 바로 순회할 수 있도록 단일 목록으로 평탄화한다.
   const posts = useMemo(() => homePostsQuery.data?.pages.flatMap((page) => page.posts) ?? [], [homePostsQuery.data]);
   const totalCount = homePostsQuery.data?.pages[0]?.totalPostCount ?? posts.length;
-  const hasPosts = posts.length > 0;
   const loadMoreRef = useInfiniteScrollObserver({
     enabled: Boolean(homePostsQuery.hasNextPage),
     isFetching: homePostsQuery.isFetchingNextPage,
@@ -85,7 +88,7 @@ export default function HomePageClient() {
               </Button>
             }
           />
-        ) : hasPosts ? (
+        ) : posts.length > 0 ? (
           <section className="space-y-3" aria-labelledby="home-posts-heading">
             <h2 id="home-posts-heading" className="sr-only">
               게시글 목록
@@ -93,16 +96,20 @@ export default function HomePageClient() {
             <ul className="space-y-9">
               {posts.map((post) => (
                 <li key={post.postId}>
-                  <Link href={`/post/${post.postId}`} className="block">
-                    <ContentCard>
-                      <ContentCardHeader
-                        authorName={post.writer.nickname}
-                        authorImage={post.writer.profileImageUrl || undefined}
-                        category={getPrimaryPostCategoryLabel(post)}
-                        meta={formatRelativeTime(post.createdAt)}
-                        viewCount={post.viewCount}
-                        isBookmarked={post.isBookmarked}
-                      />
+                  <ContentCard>
+                    <ContentCardHeader
+                      authorName={post.writer.nickname}
+                      authorImage={post.writer.profileImageUrl || undefined}
+                      category={getPrimaryPostCategoryLabel(post)}
+                      meta={formatRelativeTime(post.createdAt)}
+                      viewCount={post.viewCount}
+                      isBookmarked={post.isBookmarked}
+                      isBookmarking={bookmarkMutation.isPending}
+                      onBookmarkToggle={() =>
+                        bookmarkMutation.mutate({ postId: post.postId, isBookmarked: post.isBookmarked })
+                      }
+                    />
+                    <Link href={`/post/${post.postId}`} className="block">
                       <ContentCardBody
                         title={post.title}
                         description={post.contentPreview}
@@ -118,9 +125,9 @@ export default function HomePageClient() {
                         }
                         imageContainerClassName="rounded-[8px] bg-bg-02"
                       />
-                      <ContentCardFooter votes={post.totalVoteCount} comments={post.commentCount} />
-                    </ContentCard>
-                  </Link>
+                      <ContentCardFooter votes={post.totalVoteCount} comments={post.commentCount} className="mt-4" />
+                    </Link>
+                  </ContentCard>
                 </li>
               ))}
             </ul>

--- a/src/app/_components/home.client.tsx
+++ b/src/app/_components/home.client.tsx
@@ -47,7 +47,7 @@ export default function HomePageClient() {
   const totalCount = homePostsQuery.data?.pages[0]?.totalPostCount ?? posts.length;
   const loadMoreRef = useInfiniteScrollObserver({
     enabled: Boolean(homePostsQuery.hasNextPage),
-    isFetching: homePostsQuery.isFetchingNextPage,
+    isFetching: homePostsQuery.isFetching,
     onIntersect: homePostsQuery.fetchNextPage,
   });
 

--- a/src/app/_components/home.client.tsx
+++ b/src/app/_components/home.client.tsx
@@ -3,9 +3,19 @@
 import Link from "next/link";
 import { useMemo, useState } from "react";
 import SectionPlusIcon from "@/assets/icons/selection-plus.svg";
+import { type GetHomePostsParams, useHomePostsInfiniteQuery } from "@/features/post/api";
 import { POST_CATEGORY_VALUE_BY_LABEL, type PostCategoryLabel } from "@/features/post/constants";
-import { getPrimaryPostCategoryLabel, getPrimaryPostCategoryValue, HOME_POSTS_MOCK } from "@/features/post/model";
-import { ContentCard, ContentCardBody, ContentCardFooter, ContentCardHeader, EmptyState } from "@/shared/ui";
+import { getPrimaryPostCategoryLabel } from "@/features/post/model";
+import { useInfiniteScrollObserver } from "@/shared/hooks";
+import {
+  Button,
+  ContentCard,
+  ContentCardBody,
+  ContentCardFooter,
+  ContentCardHeader,
+  EmptyState,
+  LoadingState,
+} from "@/shared/ui";
 import { formatRelativeTime } from "@/shared/utils/format";
 import { FooterWidget } from "@/widgets/footer/ui";
 import type { SubHeadingWidgetProps } from "@/widgets/sub-heading/ui/sub-heading.widget";
@@ -14,38 +24,34 @@ import { SubHeadingWidget } from "@/widgets/sub-heading/ui/sub-heading.widget";
 type HomeCategory = Extract<NonNullable<SubHeadingWidgetProps["selectedOptions"]>[number], PostCategoryLabel>;
 type HomeSortValue = NonNullable<SubHeadingWidgetProps["sortValue"]>;
 
+const HOME_SORT_QUERY_BY_VALUE: Record<
+  HomeSortValue,
+  "LATEST" | "MOST_VIEWED" | "MOST_COMMENTED" | "MOST_PARTICIPATED"
+> = {
+  latest: "LATEST",
+  views: "MOST_VIEWED",
+  comments: "MOST_COMMENTED",
+  votes: "MOST_PARTICIPATED",
+};
+
 export default function HomePageClient() {
   const [selectedCategories, setSelectedCategories] = useState<HomeCategory[]>([]);
   const [sortValue, setSortValue] = useState<HomeSortValue>("latest");
+  const selectedCategoryQuery = selectedCategories.map((category) => POST_CATEGORY_VALUE_BY_LABEL[category]).join(",");
 
-  const posts = useMemo(() => {
-    const selectedCategoryValues = selectedCategories
-      .map((category) => POST_CATEGORY_VALUE_BY_LABEL[category])
-      .filter(Boolean);
-
-    const filtered =
-      selectedCategories.length > 0
-        ? HOME_POSTS_MOCK.filter((post) => selectedCategoryValues.includes(getPrimaryPostCategoryValue(post)))
-        : HOME_POSTS_MOCK;
-
-    const sorted = [...filtered];
-    sorted.sort((a, b) => {
-      if (sortValue === "views") {
-        return b.viewCount - a.viewCount;
-      }
-      if (sortValue === "comments") {
-        return b.commentCount - a.commentCount;
-      }
-      if (sortValue === "votes") {
-        return b.totalVoteCount - a.totalVoteCount;
-      }
-
-      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-    });
-    return sorted;
-  }, [selectedCategories, sortValue]);
-
+  const homePostsQuery = useHomePostsInfiniteQuery({
+    categories: (selectedCategoryQuery || null) as GetHomePostsParams["categories"],
+    sortBy: HOME_SORT_QUERY_BY_VALUE[sortValue],
+    pageSize: 10,
+  });
+  const posts = useMemo(() => homePostsQuery.data?.pages.flatMap((page) => page.posts) ?? [], [homePostsQuery.data]);
+  const totalCount = homePostsQuery.data?.pages[0]?.totalPostCount ?? posts.length;
   const hasPosts = posts.length > 0;
+  const loadMoreRef = useInfiniteScrollObserver({
+    enabled: Boolean(homePostsQuery.hasNextPage),
+    isFetching: homePostsQuery.isFetchingNextPage,
+    onIntersect: homePostsQuery.fetchNextPage,
+  });
 
   return (
     <div className="flex min-h-full flex-col bg-bg-01">
@@ -60,13 +66,26 @@ export default function HomePageClient() {
           <SubHeadingWidget
             selectedOptions={selectedCategories}
             sortValue={sortValue}
-            totalCount={posts.length}
+            totalCount={totalCount}
             onSelectedOptionsChange={setSelectedCategories}
             onSortValueChange={setSortValue}
           />
         </section>
 
-        {hasPosts ? (
+        {homePostsQuery.isPending ? (
+          <LoadingState className="min-h-[320px]" />
+        ) : homePostsQuery.isError ? (
+          <EmptyState
+            layout="inline"
+            title="게시글 목록을 불러오지 못했어요."
+            description="잠시 후 다시 시도해주세요."
+            action={
+              <Button type="button" onClick={() => homePostsQuery.refetch()} className="mx-auto w-fit">
+                다시 불러오기
+              </Button>
+            }
+          />
+        ) : hasPosts ? (
           <section className="space-y-3" aria-labelledby="home-posts-heading">
             <h2 id="home-posts-heading" className="sr-only">
               게시글 목록
@@ -88,7 +107,14 @@ export default function HomePageClient() {
                         title={post.title}
                         description={post.contentPreview}
                         image={
-                          <div className={`aspect-[5/3] w-full rounded-[8px] bg-gradient-to-br ${post.thumbnailUrl}`} />
+                          post.thumbnailUrl ? (
+                            // biome-ignore lint/performance/noImgElement: 외부 이미지 도메인 정책은 이미지 연동 이슈에서 정리한다.
+                            <img
+                              src={post.thumbnailUrl}
+                              alt={`${post.title} 썸네일`}
+                              className="aspect-[5/3] w-full rounded-[8px] object-cover"
+                            />
+                          ) : undefined
                         }
                         imageContainerClassName="rounded-[8px] bg-bg-02"
                       />
@@ -98,6 +124,11 @@ export default function HomePageClient() {
                 </li>
               ))}
             </ul>
+            <div ref={loadMoreRef} className="flex min-h-8 items-center justify-center py-2">
+              {homePostsQuery.isFetchingNextPage ? (
+                <span className="text-caption-m text-text-03">게시글을 더 불러오는 중...</span>
+              ) : null}
+            </div>
           </section>
         ) : (
           <section className="flex flex-1 items-center justify-center" aria-label="게시글 없음">

--- a/src/app/_components/home.client.tsx
+++ b/src/app/_components/home.client.tsx
@@ -3,8 +3,13 @@
 import Link from "next/link";
 import { useMemo, useState } from "react";
 import SectionPlusIcon from "@/assets/icons/selection-plus.svg";
-import { type GetHomePostsParams, useHomePostsInfiniteQuery, useTogglePostBookmarkMutation } from "@/features/post/api";
-import { POST_CATEGORY_VALUE_BY_LABEL, type PostCategoryLabel } from "@/features/post/constants";
+import { useHomePostsInfiniteQuery, useTogglePostBookmarkMutation } from "@/features/post/api";
+import {
+  POST_CATEGORY_VALUE_BY_LABEL,
+  POST_LIST_PAGE_SIZE,
+  POST_SORT_QUERY_BY_VALUE,
+  type PostCategoryLabel,
+} from "@/features/post/constants";
 import { getPrimaryPostCategoryLabel } from "@/features/post/model";
 import { useInfiniteScrollObserver } from "@/shared/hooks";
 import {
@@ -23,16 +28,6 @@ import { SubHeadingWidget, type SubHeadingWidgetProps } from "@/widgets/sub-head
 type HomeCategory = Extract<NonNullable<SubHeadingWidgetProps["selectedOptions"]>[number], PostCategoryLabel>;
 type HomeSortValue = NonNullable<SubHeadingWidgetProps["sortValue"]>;
 
-const HOME_SORT_QUERY_BY_VALUE: Record<
-  HomeSortValue,
-  "LATEST" | "MOST_VIEWED" | "MOST_COMMENTED" | "MOST_PARTICIPATED"
-> = {
-  latest: "LATEST",
-  views: "MOST_VIEWED",
-  comments: "MOST_COMMENTED",
-  votes: "MOST_PARTICIPATED",
-};
-
 export default function HomePageClient() {
   const [selectedCategories, setSelectedCategories] = useState<HomeCategory[]>([]);
   const [sortValue, setSortValue] = useState<HomeSortValue>("latest");
@@ -42,9 +37,9 @@ export default function HomePageClient() {
   const selectedCategoryQuery = selectedCategories.map((category) => POST_CATEGORY_VALUE_BY_LABEL[category]).join(",");
 
   const homePostsQuery = useHomePostsInfiniteQuery({
-    categories: (selectedCategoryQuery || null) as GetHomePostsParams["categories"],
-    sortBy: HOME_SORT_QUERY_BY_VALUE[sortValue],
-    pageSize: 10,
+    categories: selectedCategoryQuery || null,
+    sortBy: POST_SORT_QUERY_BY_VALUE[sortValue],
+    pageSize: POST_LIST_PAGE_SIZE,
   });
 
   // infinite query 응답을 화면에서 바로 순회할 수 있도록 단일 목록으로 평탄화한다.

--- a/src/app/mypage/history/_components/mypage-history-page.client.tsx
+++ b/src/app/mypage/history/_components/mypage-history-page.client.tsx
@@ -158,6 +158,7 @@ export default function MypageHistoryPageClient() {
               items={items}
               onBookmarkRemove={(postId) => deleteBookmarkMutation.mutate({ postId })}
               hasNextPage={activeQuery.hasNextPage}
+              isFetching={activeQuery.isFetching}
               isFetchingNextPage={activeQuery.isFetchingNextPage}
               onLoadMore={() => {
                 activeQuery.fetchNextPage();

--- a/src/app/post/[postId]/_components/post-detail.client.tsx
+++ b/src/app/post/[postId]/_components/post-detail.client.tsx
@@ -224,6 +224,7 @@ export default function PostDetailPageClient({ postId }: PostDetailPageClientPro
             onToggleHelpful={commentsState.handleToggleCommentHelpful}
             isCreatingComment={commentsState.isCreatingComment}
             hasNextPage={Boolean(commentsState.commentsQuery.hasNextPage)}
+            isFetching={commentsState.commentsQuery.isFetching}
             isFetchingNextPage={commentsState.commentsQuery.isFetchingNextPage}
             onLoadMore={commentsState.handleLoadMoreComments}
           />

--- a/src/features/mypage/history/ui/mypage-history-section.tsx
+++ b/src/features/mypage/history/ui/mypage-history-section.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { clsx } from "clsx";
-import { useEffect, useRef } from "react";
 import BookmarkFillIcon from "@/assets/icons/bookmark-simple-fill.svg";
 import ChatIcon from "@/assets/icons/chat.svg";
 import { MYPAGE_HISTORY_RESULT_COPY } from "@/features/mypage/history/constants";
 import type { HistoryResult, MypageHistoryItem, MypageHistoryTab } from "@/features/mypage/history/model";
+import { useInfiniteScrollObserver } from "@/shared/hooks";
 import { EmptyState, LoadingState, Tag } from "@/shared/ui";
 import { cn } from "@/shared/utils";
 
@@ -151,30 +151,11 @@ export function MypageHistorySection({
   isFetchingNextPage = false,
   onLoadMore,
 }: MypageHistorySectionProps) {
-  const loadMoreRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!hasNextPage || isFetchingNextPage || !onLoadMore) {
-      return;
-    }
-
-    const target = loadMoreRef.current;
-    if (!target) {
-      return;
-    }
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry?.isIntersecting) {
-          onLoadMore();
-        }
-      },
-      { rootMargin: "160px 0px" },
-    );
-
-    observer.observe(target);
-    return () => observer.disconnect();
-  }, [hasNextPage, isFetchingNextPage, onLoadMore]);
+  const loadMoreRef = useInfiniteScrollObserver({
+    enabled: hasNextPage,
+    isFetching: isFetchingNextPage,
+    onIntersect: onLoadMore,
+  });
 
   if (items.length === 0) {
     return (
@@ -197,7 +178,7 @@ export function MypageHistorySection({
           <li key={item.id}>{renderHistoryCard(activeTab, item, onBookmarkRemove)}</li>
         ))}
       </ul>
-      {hasNextPage ? <div ref={loadMoreRef} aria-hidden className="h-6" /> : null}
+      <div ref={loadMoreRef} aria-hidden className="h-6" />
       {isFetchingNextPage ? <LoadingState className="min-h-20" /> : null}
     </section>
   );

--- a/src/features/mypage/history/ui/mypage-history-section.tsx
+++ b/src/features/mypage/history/ui/mypage-history-section.tsx
@@ -14,6 +14,7 @@ type MypageHistorySectionProps = {
   items: MypageHistoryItem[];
   onBookmarkRemove?: (postId: number) => void;
   hasNextPage?: boolean;
+  isFetching?: boolean;
   isFetchingNextPage?: boolean;
   onLoadMore?: () => void;
 };
@@ -148,12 +149,13 @@ export function MypageHistorySection({
   items,
   onBookmarkRemove,
   hasNextPage = false,
+  isFetching = false,
   isFetchingNextPage = false,
   onLoadMore,
 }: MypageHistorySectionProps) {
   const loadMoreRef = useInfiniteScrollObserver({
     enabled: hasNextPage,
-    isFetching: isFetchingNextPage,
+    isFetching,
     onIntersect: onLoadMore,
   });
 

--- a/src/features/post/api/post.query.ts
+++ b/src/features/post/api/post.query.ts
@@ -1,8 +1,15 @@
 "use client";
 
-import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  type InfiniteData,
+  type QueryClient,
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { unwrapApiResult } from "@/shared/api";
-import type { CommentItemResponse } from "@/shared/api/generated";
+import type { CommentItemResponse, HomePostListResponse } from "@/shared/api/generated";
 import { getCommentsAction, getHomePostsAction, getPostDetailAction } from "./post.action";
 import {
   createBookmarkWithAuth,
@@ -17,6 +24,31 @@ import {
 import { postQueryKeys } from "./post.keys";
 import type { GetCommentsParams, GetHomePostsParams } from "./post.service";
 
+type HomePostsInfiniteData = InfiniteData<HomePostListResponse>;
+
+function updateHomePostBookmarkState(data: HomePostsInfiniteData | undefined, postId: number, isBookmarked: boolean) {
+  return data
+    ? {
+        ...data,
+        pages: data.pages.map((page) => ({
+          ...page,
+          posts: page.posts.map((post) => (post.postId === postId ? { ...post, isBookmarked } : post)),
+        })),
+      }
+    : data;
+}
+
+function setHomePostBookmarkState(queryClient: QueryClient, postId: number, isBookmarked: boolean) {
+  queryClient.setQueriesData<HomePostsInfiniteData>({ queryKey: postQueryKeys.lists() }, (old) =>
+    updateHomePostBookmarkState(old, postId, isBookmarked),
+  );
+}
+
+type TogglePostBookmarkVariables = {
+  postId: number;
+  isBookmarked: boolean;
+};
+
 export function useHomePostsQuery(params: GetHomePostsParams = {}) {
   return useQuery({
     queryKey: postQueryKeys.list(params),
@@ -25,6 +57,7 @@ export function useHomePostsQuery(params: GetHomePostsParams = {}) {
 }
 
 export function useHomePostsInfiniteQuery(params: Omit<GetHomePostsParams, "cursor"> = {}) {
+  // 홈 피드 무한 스크롤 쿼리: cursor는 query 내부 pageParam으로만 관리한다.
   return useInfiniteQuery({
     queryKey: postQueryKeys.list(params),
     queryFn: ({ pageParam }) =>
@@ -78,13 +111,33 @@ export function useDeletePostMutation(postId: number) {
   });
 }
 
-export function useTogglePostBookmarkMutation(postId: number) {
+export function useTogglePostBookmarkMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (isBookmarked: boolean) =>
+    mutationFn: ({ postId, isBookmarked }: TogglePostBookmarkVariables) =>
       isBookmarked ? deleteBookmarkWithAuth({ postId }) : createBookmarkWithAuth({ postId }),
-    onSuccess: () => {
+    onMutate: async ({ postId, isBookmarked }) => {
+      await queryClient.cancelQueries({ queryKey: postQueryKeys.lists() });
+      const previousHomePostLists = queryClient.getQueriesData<HomePostsInfiniteData>({
+        queryKey: postQueryKeys.lists(),
+      });
+
+      // 낙관적 업데이트: 홈 피드에 로드된 같은 게시글의 북마크 상태를 즉시 반전한다.
+      setHomePostBookmarkState(queryClient, postId, !isBookmarked);
+
+      return { previousHomePostLists };
+    },
+    onSuccess: (result, { postId }) => {
+      // 서버 응답을 한 번 더 반영해 중복 클릭/동시 요청으로 인한 표시 오차를 줄인다.
+      setHomePostBookmarkState(queryClient, postId, result.isBookmarked);
+    },
+    onError: (_error, _variables, context) => {
+      context?.previousHomePostLists.forEach(([queryKey, data]) => {
+        queryClient.setQueryData(queryKey, data);
+      });
+    },
+    onSettled: (_result, _error, { postId }) => {
       queryClient.invalidateQueries({ queryKey: postQueryKeys.detail(postId) });
       queryClient.invalidateQueries({ queryKey: postQueryKeys.lists() });
     },

--- a/src/features/post/api/post.query.ts
+++ b/src/features/post/api/post.query.ts
@@ -49,13 +49,6 @@ type TogglePostBookmarkVariables = {
   isBookmarked: boolean;
 };
 
-export function useHomePostsQuery(params: GetHomePostsParams = {}) {
-  return useQuery({
-    queryKey: postQueryKeys.list(params),
-    queryFn: () => getHomePostsAction(params).then(unwrapApiResult),
-  });
-}
-
 export function useHomePostsInfiniteQuery(params: Omit<GetHomePostsParams, "cursor"> = {}) {
   // 홈 피드 무한 스크롤 쿼리: cursor는 query 내부 pageParam으로만 관리한다.
   return useInfiniteQuery({

--- a/src/features/post/api/post.service.ts
+++ b/src/features/post/api/post.service.ts
@@ -7,7 +7,10 @@ import type {
   PostDetailResponse,
 } from "@/shared/api/generated";
 
-export type GetHomePostsParams = GetHomePostsQuery;
+export type GetHomePostsParams = Omit<GetHomePostsQuery, "categories"> & {
+  /** 쉼표로 구분된 카테고리 코드들 */
+  categories?: string | null;
+};
 export type GetCommentsParams = GetCommentsQuery;
 
 export async function getHomePosts(params: GetHomePostsParams = {}) {

--- a/src/features/post/constants/post-filter.constants.ts
+++ b/src/features/post/constants/post-filter.constants.ts
@@ -32,3 +32,29 @@ export const POST_SORT_OPTIONS = [
   { value: "comments", label: "댓글순" },
   { value: "votes", label: "투표 참여순" },
 ] as const;
+
+export const POST_LIST_PAGE_SIZE = 10;
+
+export type PostSortValue = (typeof POST_SORT_OPTIONS)[number]["value"];
+export type PostSortQueryValue = "LATEST" | "MOST_VIEWED" | "MOST_COMMENTED" | "MOST_PARTICIPATED";
+
+export const POST_SORT_QUERY_BY_VALUE = {
+  latest: "LATEST",
+  views: "MOST_VIEWED",
+  comments: "MOST_COMMENTED",
+  votes: "MOST_PARTICIPATED",
+} satisfies Record<PostSortValue, PostSortQueryValue>;
+
+export type PostCommentSortValue = "latest" | "helpful";
+
+export const COMMENT_PAGE_SIZE = 15;
+
+export const COMMENT_SORT_OPTIONS = [
+  { value: "latest", label: "최신순" },
+  { value: "helpful", label: "유익해요순" },
+] as const satisfies readonly { value: PostCommentSortValue; label: string }[];
+
+export const COMMENT_SORT_QUERY_BY_VALUE = {
+  latest: "LATEST",
+  helpful: "HELPFUL",
+} satisfies Record<PostCommentSortValue, "LATEST" | "HELPFUL">;

--- a/src/features/post/hooks/use-post-detail-bookmark-state.hook.ts
+++ b/src/features/post/hooks/use-post-detail-bookmark-state.hook.ts
@@ -32,7 +32,7 @@ type UsePostDetailBookmarkStateParams = {
 export function usePostDetailBookmarkState(params: UsePostDetailBookmarkStateParams) {
   const { postId, post, onAuthRequired } = params;
   const [isBookmarked, setIsBookmarked] = useState(false);
-  const togglePostBookmarkMutation = useTogglePostBookmarkMutation(postId);
+  const togglePostBookmarkMutation = useTogglePostBookmarkMutation();
 
   useEffect(() => {
     if (!post) {
@@ -51,7 +51,7 @@ export function usePostDetailBookmarkState(params: UsePostDetailBookmarkStatePar
 
     setIsBookmarked(!previousBookmarked);
     try {
-      const result = await togglePostBookmarkMutation.mutateAsync(previousBookmarked);
+      const result = await togglePostBookmarkMutation.mutateAsync({ postId, isBookmarked: previousBookmarked });
       setIsBookmarked(result.isBookmarked);
     } catch (error) {
       setIsBookmarked(previousBookmarked);

--- a/src/features/post/hooks/use-post-detail-comments.hook.ts
+++ b/src/features/post/hooks/use-post-detail-comments.hook.ts
@@ -8,13 +8,8 @@ import {
   useToggleCommentHelpfulMutation,
   useUpdateCommentMutation,
 } from "@/features/post/api";
-import type { PostCommentSortValue } from "@/features/post/ui";
+import { COMMENT_PAGE_SIZE, COMMENT_SORT_QUERY_BY_VALUE, type PostCommentSortValue } from "@/features/post/constants";
 import type { CommentItemResponse } from "@/shared/api/generated";
-
-const COMMENT_SORT_QUERY_BY_VALUE: Record<PostCommentSortValue, "LATEST" | "HELPFUL"> = {
-  latest: "LATEST",
-  helpful: "HELPFUL",
-};
 
 type UsePostDetailCommentsParams = {
   postId: number;
@@ -48,7 +43,7 @@ export function usePostDetailComments(params: UsePostDetailCommentsParams) {
   const [commentSortValue, setCommentSortValue] = useState<PostCommentSortValue>("latest");
   const commentsQuery = useCommentsInfiniteQuery(postId, {
     sortBy: COMMENT_SORT_QUERY_BY_VALUE[commentSortValue],
-    pageSize: 15,
+    pageSize: COMMENT_PAGE_SIZE,
   });
   const createCommentMutation = useCreateCommentMutation(postId);
   const updateCommentMutation = useUpdateCommentMutation(postId);

--- a/src/features/post/ui/post-comments-section.tsx
+++ b/src/features/post/ui/post-comments-section.tsx
@@ -6,8 +6,7 @@ import ChatIcon from "@/assets/icons/chat.svg";
 import { PostCommentCard } from "@/features/post/ui/post-comment-card";
 import { PostCommentForm } from "@/features/post/ui/post-comment-form";
 import type { CommentItemResponse, CommentReadResponse } from "@/shared/api/generated";
-// TODO: 공용 useInfiniteScrollObserver가 홈 피드 PR에 포함되면 주석을 해제해 댓글 무한스크롤도 다시 연결한다.
-// import { useInfiniteScrollObserver } from "@/shared/hooks";
+import { useInfiniteScrollObserver } from "@/shared/hooks";
 import { SortSelect, type SortSelectOption } from "@/shared/ui";
 import { cn } from "@/shared/utils";
 
@@ -60,11 +59,11 @@ export function PostCommentsSection(props: PostCommentsSectionProps) {
     ...rest
   } = props;
   const comments = commentsResponse.comments;
-  // const loadMoreRef = useInfiniteScrollObserver({
-  //   enabled: hasNextPage,
-  //   isFetching: isFetchingNextPage,
-  //   onIntersect: onLoadMore,
-  // });
+  const loadMoreRef = useInfiniteScrollObserver({
+    enabled: hasNextPage,
+    isFetching: isFetchingNextPage,
+    onIntersect: onLoadMore,
+  });
   const rootComments = useMemo(() => {
     const roots = comments.filter((comment) => comment.parentId === null);
     const sorted = [...roots];
@@ -134,9 +133,9 @@ export function PostCommentsSection(props: PostCommentsSectionProps) {
       ) : (
         <EmptyComments />
       )}
-      {/* <div ref={loadMoreRef} className="flex min-h-8 items-center justify-center py-2">
-        {isFetchingNextPage ? <span className="text-caption-m text-text-03">댓글을 더 불러오는 중...</span> : null}
-      </div> */}
+      <div ref={loadMoreRef} className="flex min-h-8 items-center justify-center py-2">
+        {isFetchingNextPage ? <span className="text-caption-m text-text-03">댓글 불러오는 중...</span> : null}
+      </div>
     </section>
   );
 }

--- a/src/features/post/ui/post-comments-section.tsx
+++ b/src/features/post/ui/post-comments-section.tsx
@@ -22,6 +22,7 @@ export type PostCommentsSectionProps = ComponentProps<"section"> & {
   onToggleHelpful: (comment: CommentItemResponse) => Promise<{ isHelpful: boolean; totalHelpfulCount: number }>;
   isCreatingComment?: boolean;
   hasNextPage?: boolean;
+  isFetching?: boolean;
   isFetchingNextPage?: boolean;
   onLoadMore?: () => Promise<unknown>;
 };
@@ -47,6 +48,7 @@ export function PostCommentsSection(props: PostCommentsSectionProps) {
     onToggleHelpful,
     isCreatingComment = false,
     hasNextPage = false,
+    isFetching = false,
     isFetchingNextPage = false,
     onLoadMore,
     className,
@@ -55,7 +57,7 @@ export function PostCommentsSection(props: PostCommentsSectionProps) {
   const comments = commentsResponse.comments;
   const loadMoreRef = useInfiniteScrollObserver({
     enabled: hasNextPage,
-    isFetching: isFetchingNextPage,
+    isFetching,
     onIntersect: onLoadMore,
   });
   const rootComments = useMemo(() => {

--- a/src/features/post/ui/post-comments-section.tsx
+++ b/src/features/post/ui/post-comments-section.tsx
@@ -3,14 +3,13 @@
 import type { ComponentProps } from "react";
 import { useMemo } from "react";
 import ChatIcon from "@/assets/icons/chat.svg";
+import { COMMENT_SORT_OPTIONS, type PostCommentSortValue } from "@/features/post/constants";
 import { PostCommentCard } from "@/features/post/ui/post-comment-card";
 import { PostCommentForm } from "@/features/post/ui/post-comment-form";
 import type { CommentItemResponse, CommentReadResponse } from "@/shared/api/generated";
 import { useInfiniteScrollObserver } from "@/shared/hooks";
-import { SortSelect, type SortSelectOption } from "@/shared/ui";
+import { SortSelect } from "@/shared/ui";
 import { cn } from "@/shared/utils";
-
-export type PostCommentSortValue = "latest" | "helpful";
 
 export type PostCommentsSectionProps = ComponentProps<"section"> & {
   commentsResponse: CommentReadResponse;
@@ -26,11 +25,6 @@ export type PostCommentsSectionProps = ComponentProps<"section"> & {
   isFetchingNextPage?: boolean;
   onLoadMore?: () => Promise<unknown>;
 };
-
-const COMMENT_SORT_OPTIONS = [
-  { value: "latest", label: "최신순" },
-  { value: "helpful", label: "유익해요순" },
-] satisfies readonly SortSelectOption<PostCommentSortValue>[];
 
 function EmptyComments() {
   return (

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -1,0 +1,5 @@
+export * from "./use-controllable-input-value";
+export * from "./use-horizontal-drag-scroll";
+export * from "./use-infinite-scroll-observer";
+export * from "./use-post-image-carousel-order";
+export * from "./use-post-image-tile-state";

--- a/src/shared/hooks/use-infinite-scroll-observer.ts
+++ b/src/shared/hooks/use-infinite-scroll-observer.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+type UseInfiniteScrollObserverParams = {
+  enabled: boolean;
+  isFetching?: boolean;
+  rootMargin?: string;
+  onIntersect?: () => unknown;
+};
+
+/**
+ * 무한스크롤 sentinel element의 IntersectionObserver 등록을 관리하는 훅
+ *
+ * @description
+ * sentinel element는 layout 높이 변화를 줄이기 위해 항상 렌더링하고,
+ * 실제 observer 등록과 다음 페이지 호출 여부만 `enabled`, `isFetching` 값으로 제어합니다.
+ *
+ * @param params.enabled - 다음 페이지 호출 가능 여부입니다.
+ * @param params.isFetching - 다음 페이지 호출 진행 여부입니다.
+ * @param params.rootMargin - observer rootMargin 값입니다.
+ * @param params.onIntersect - sentinel이 화면 근처에 들어왔을 때 실행할 핸들러입니다.
+ *
+ * @returns loadMoreRef - sentinel element에 연결할 ref입니다.
+ */
+export function useInfiniteScrollObserver(params: UseInfiniteScrollObserverParams) {
+  const { enabled, isFetching = false, rootMargin = "160px 0px", onIntersect } = params;
+  const loadMoreRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const target = loadMoreRef.current;
+    if (!target || !enabled || isFetching || !onIntersect) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) {
+          onIntersect();
+        }
+      },
+      { rootMargin },
+    );
+
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [enabled, isFetching, onIntersect, rootMargin]);
+
+  return loadMoreRef;
+}

--- a/src/shared/ui/content-card.tsx
+++ b/src/shared/ui/content-card.tsx
@@ -30,6 +30,8 @@ export type ContentCardHeaderProps = {
   className?: string;
   viewCount?: number;
   isBookmarked?: boolean;
+  isBookmarking?: boolean;
+  onBookmarkToggle?: () => void;
 };
 
 export function ContentCardHeader({
@@ -39,6 +41,8 @@ export function ContentCardHeader({
   meta,
   viewCount,
   isBookmarked = false,
+  isBookmarking = false,
+  onBookmarkToggle,
   className,
 }: ContentCardHeaderProps) {
   const fallbackInitial = (authorName ?? "?").trim().charAt(0) || "?";
@@ -75,7 +79,22 @@ export function ContentCardHeader({
           <Tag tone="categoryInactive" size="sm">
             {category}
           </Tag>
-          {isBookmarked ? (
+          {onBookmarkToggle ? (
+            <button
+              type="button"
+              aria-label={isBookmarked ? "북마크 해제" : "북마크"}
+              aria-pressed={isBookmarked}
+              disabled={isBookmarking}
+              onClick={onBookmarkToggle}
+              className="flex size-6 items-center justify-center disabled:opacity-60"
+            >
+              {isBookmarked ? (
+                <BookmarkFillIcon aria-hidden className="size-6 text-text-02" />
+              ) : (
+                <BookmarkIcon aria-hidden className="size-6 text-text-02" strokeWidth={20} />
+              )}
+            </button>
+          ) : isBookmarked ? (
             <BookmarkFillIcon aria-hidden className="size-6 text-text-02" />
           ) : (
             <BookmarkIcon aria-hidden className="size-6 text-text-02" strokeWidth={20} />


### PR DESCRIPTION
## 📋 변경 사항

홈 피드의 mock data 의존을 제거하고 백엔드 게시글 목록 API 기반으로 데이터를 조회하도록 연동했습니다.

- 홈 피드 게시글 목록 API 연동
- 홈 피드 cursor 기반 무한스크롤 적용
- 공용 무한스크롤 observer hook 추가
- 마이페이지 히스토리 무한스크롤 hook 적용
- 홈 피드 북마크 토글 API 연동
- 홈 피드 북마크 낙관적 업데이트 및 실패 시 rollback 처리
- `ContentCardHeader` 북마크 액션 지원
- 홈 피드 조회 파라미터 타입 정리
- 게시글 필터/정렬 관련 상수 정리
- 댓글 무한스크롤 재연결

## 🏷️ PR 유형

- [x] 🚀 feat: 새로운 기능 추가
- [x] 🐛 fix: 버그 수정
- [x] ♻️ refactor: 코드 리팩토링
- [ ] 📝 docs: 문서 수정
- [ ] ✅ test: 테스트 코드 추가/수정
- [ ] 🔧 chore: 빌드/패키지 매니저 수정

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션 준수
- [x] 로컬 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📸 테스트 결과

이슈 및 빌드에러 X

## 🔗 관련 이슈

- Closes #52